### PR TITLE
fix: support bare array format for SUPABASE_JWKS

### DIFF
--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -99,6 +99,39 @@ describe('resolveEnv', () => {
     })
   })
 
+  it('parses platform env vars with multiple keys and JWKS array', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv(
+      'SUPABASE_PUBLISHABLE_KEYS',
+      '{"default":"sb_publishable_fake_default_key","test":"sb_publishable_fake_test_key"}',
+    )
+    vi.stubEnv(
+      'SUPABASE_SECRET_KEYS',
+      '{"default":"sb_secret_fake_default_key_val","internal":"sb_secret_fake_internal_key"}',
+    )
+    vi.stubEnv(
+      'SUPABASE_JWKS',
+      '[{"x":"aN7ek2W_m0BCBoy2vnfwd_785kEfMCcAMGznUg3ut34","y":"7vftLMpD-fRUFmhrqOIfS6ApmCzKgbE6dFsP4o5BCso","alg":"ES256","crv":"P-256","ext":true,"kid":"cb770052-bdd3-4f5e-8d6f-8836046b7c93","kty":"EC","key_ops":["verify"]},{"x":"vwGP-KLJgwv0LHlZEd-7AksGdnznPFcodh4kEKjWUV0","y":"hOyozpKPMwFu8iFGC6QJLqOmDdrNTLyBxiWhKoSSg58","alg":"ES256","crv":"P-256","ext":true,"kid":"9a9933f7-e18f-4d6f-a791-9a992845a27b","kty":"EC","key_ops":["verify"]}]',
+    )
+    const result = resolveEnv()
+    expect(result.error).toBeNull()
+    expect(result.data!.publishableKeys).toEqual({
+      default: 'sb_publishable_fake_default_key',
+      test: 'sb_publishable_fake_test_key',
+    })
+    expect(result.data!.secretKeys).toEqual({
+      default: 'sb_secret_fake_default_key_val',
+      internal: 'sb_secret_fake_internal_key',
+    })
+    expect(result.data!.jwks!.keys).toHaveLength(2)
+    expect((result.data!.jwks!.keys[0] as Record<string, unknown>).kid).toBe(
+      'cb770052-bdd3-4f5e-8d6f-8836046b7c93',
+    )
+    expect((result.data!.jwks!.keys[1] as Record<string, unknown>).kid).toBe(
+      '9a9933f7-e18f-4d6f-a791-9a992845a27b',
+    )
+  })
+
   it('uses overrides when provided', () => {
     const result = resolveEnv({
       url: 'https://override.supabase.co',

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -66,6 +66,20 @@ describe('resolveEnv', () => {
     expect(result.data!.jwks).toBeNull()
   })
 
+  it.each([
+    ['a primitive', '1'],
+    ['an empty object', '{}'],
+    ['an object with non-array keys', '{"keys":"nope"}'],
+    ['a string', '"hello"'],
+    ['null', 'null'],
+    ['a boolean', 'true'],
+  ])('returns null jwks for valid JSON that is %s', (_label, value) => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS', value)
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeNull()
+  })
+
   it('reads singular SUPABASE_PUBLISHABLE_KEY as { default: value }', () => {
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
     vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', 'sb_publishable_test_123')

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -51,6 +51,14 @@ describe('resolveEnv', () => {
     expect(result.data!.jwks).toEqual(jwks)
   })
 
+  it('wraps bare JWKS array in { keys } object', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    const keys = [{ kty: 'EC', crv: 'P-256', x: 'test', y: 'test' }]
+    vi.stubEnv('SUPABASE_JWKS', JSON.stringify(keys))
+    const result = resolveEnv()
+    expect(result.data!.jwks).toEqual({ keys })
+  })
+
   it('returns null jwks for invalid JSON', () => {
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
     vi.stubEnv('SUPABASE_JWKS', 'not-json')

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -44,7 +44,10 @@ function resolveKeys(
 function parseJwks(raw: string | undefined): JsonWebKeySet | null {
   if (!raw) return null
   try {
-    return JSON.parse(raw) as JsonWebKeySet
+    const parsed = JSON.parse(raw)
+    // Support both { keys: [...] } and bare array [...] formats
+    if (Array.isArray(parsed)) return { keys: parsed }
+    return parsed as JsonWebKeySet
   } catch {
     return null
   }

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -47,7 +47,9 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | null {
     const parsed = JSON.parse(raw)
     // Support both { keys: [...] } and bare array [...] formats
     if (Array.isArray(parsed)) return { keys: parsed }
-    return parsed as JsonWebKeySet
+    if (parsed?.keys && Array.isArray(parsed.keys))
+      return parsed as JsonWebKeySet
+    return null
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- The Supabase platform provides `SUPABASE_JWKS` as a bare JSON array `[{...}]`, but `parseJwks` expected `{ keys: [...] }` format
- Now auto-wraps bare arrays in `{ keys: [...] }` so both formats work
- Adds integration test using realistic platform env var shapes
