### PR TITLE
docs: add TSDoc comments with embedded examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ TBD
 1. Fork and clone the repository:
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/edge-functions.git
-cd edge-functions
+git clone https://github.com/YOUR_USERNAME/server.git
+cd server
 ```
 
 2. Install dependencies:

--- a/src/adapters/hono/index.ts
+++ b/src/adapters/hono/index.ts
@@ -1,13 +1,15 @@
 /**
- * Hono framework adapter for `@supabase/edge-functions`.
+ * Hono framework adapter for `@supabase/server`.
  *
- * Provides a Hono middleware version of {@link withSupabase} that stores the
- * {@link SupabaseContext} in `c.var.supabaseContext`.
+ * The top-level {@link withSupabase} is built for the raw Web API `Request`/`Response`
+ * standard. Frameworks like Hono wrap that standard with their own abstractions
+ * (context objects, middleware chains, typed variables). This adapter bridges the
+ * gap — same auth and client creation, delivered through `c.var.supabaseContext`.
  *
  * @example
  * ```ts
  * import { Hono } from 'hono'
- * import { withSupabase } from '@supabase/edge-functions/adapters/hono'
+ * import { withSupabase } from '@supabase/server/adapters/hono'
  *
  * const app = new Hono()
  * app.use('*', withSupabase({ allow: 'user' }))

--- a/src/adapters/hono/index.ts
+++ b/src/adapters/hono/index.ts
@@ -1,1 +1,27 @@
+/**
+ * Hono framework adapter for `@supabase/edge-functions`.
+ *
+ * Provides a Hono middleware version of {@link withSupabase} that stores the
+ * {@link SupabaseContext} in `c.var.supabaseContext`.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono'
+ * import { withSupabase } from '@supabase/edge-functions/adapters/hono'
+ *
+ * const app = new Hono()
+ * app.use('*', withSupabase({ allow: 'user' }))
+ *
+ * app.get('/items', async (c) => {
+ *   const { supabase } = c.var.supabaseContext
+ *   const { data } = await supabase.rpc('list_items')
+ *   return c.json(data)
+ * })
+ *
+ * export default { fetch: app.fetch }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
 export { withSupabase } from './middleware.js'

--- a/src/adapters/hono/index.ts
+++ b/src/adapters/hono/index.ts
@@ -1,28 +1,6 @@
 /**
  * Hono framework adapter for `@supabase/server`.
  *
- * The top-level {@link withSupabase} is built for the raw Web API `Request`/`Response`
- * standard. Frameworks like Hono wrap that standard with their own abstractions
- * (context objects, middleware chains, typed variables). This adapter bridges the
- * gap — same auth and client creation, delivered through `c.var.supabaseContext`.
- *
- * @example
- * ```ts
- * import { Hono } from 'hono'
- * import { withSupabase } from '@supabase/server/adapters/hono'
- *
- * const app = new Hono()
- * app.use('*', withSupabase({ allow: 'user' }))
- *
- * app.get('/items', async (c) => {
- *   const { supabase } = c.var.supabaseContext
- *   const { data } = await supabase.rpc('list_items')
- *   return c.json(data)
- * })
- *
- * export default { fetch: app.fetch }
- * ```
- *
  * @packageDocumentation
  */
 

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -7,73 +7,27 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
 /**
  * Hono middleware that creates a {@link SupabaseContext} and stores it in `c.var.supabaseContext`.
  *
- * Frameworks like Hono wrap the runtime's native `Request`/`Response` with their
- * own abstractions (context objects, middleware chains, typed variables). This adapter
- * bridges that gap — it performs the same auth and client creation as the top-level
- * {@link withSupabase}, but delivers the result through Hono's context variables
- * instead of a handler argument.
+ * Skips if a previous middleware already set the context, enabling route-level overrides.
+ * Throws a Hono `HTTPException` on auth failure.
  *
- * **Middleware stacking:** If a previous middleware already set `supabaseContext`,
- * this middleware is skipped. This enables route-level overrides — a route can use
- * `withSupabase({ allow: 'secret' })` while the app-wide middleware uses
- * `withSupabase({ allow: 'user' })`, without the app-wide one overwriting
- * the stricter context.
- *
- * **CORS:** The `cors` option from {@link WithSupabaseConfig} is intentionally excluded.
- * Use Hono's built-in `cors()` middleware instead.
- *
- * **Error handling:** On auth failure, throws a Hono `HTTPException` with the
- * appropriate status code, which Hono converts to an error response.
- *
- * @param config - Auth modes and optional environment overrides.
- *   The `cors` property is omitted — handle CORS with Hono's `cors()` middleware.
- *
+ * @param config - Auth modes and optional environment overrides. CORS is excluded — use Hono's `cors()`.
  * @returns A Hono middleware that sets `c.var.supabaseContext`.
  *
- * @example Basic usage — protect all routes
+ * @example
  * ```ts
  * import { Hono } from 'hono'
  * import { withSupabase } from '@supabase/server/adapters/hono'
  *
  * const app = new Hono()
- *
- * // Apply to all routes
  * app.use('*', withSupabase({ allow: 'user' }))
  *
  * app.get('/profile', async (c) => {
- *   const { supabase, userClaims } = c.var.supabaseContext
+ *   const { supabase } = c.var.supabaseContext
  *   const { data } = await supabase.rpc('get_profile')
- *   return c.json({ profile: data, userId: userClaims!.id })
+ *   return c.json(data)
  * })
  *
  * export default { fetch: app.fetch }
- * ```
- *
- * @example Route-level overrides
- * ```ts
- * const app = new Hono()
- *
- * // App-wide: require authenticated user
- * app.use('*', withSupabase({ allow: 'user' }))
- *
- * // This route requires a secret key instead
- * app.post('/webhooks/stripe', withSupabase({ allow: 'secret' }), async (c) => {
- *   const { supabaseAdmin } = c.var.supabaseContext
- *   // The route-level middleware ran first, so the app-wide one is skipped
- *   return c.json({ ok: true })
- * })
- * ```
- *
- * @example Multiple auth modes
- * ```ts
- * app.use('*', withSupabase({ allow: ['user', 'public'] }))
- *
- * app.get('/items', async (c) => {
- *   const { supabase, authType } = c.var.supabaseContext
- *   // authType is 'user' or 'public' depending on the request
- *   const { data } = await supabase.rpc('list_items')
- *   return c.json(data)
- * })
  * ```
  */
 export function withSupabase(config?: Omit<WithSupabaseConfig, 'cors'>) {

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -4,6 +4,76 @@ import { createMiddleware } from 'hono/factory'
 import { createSupabaseContext } from '../../create-supabase-context.js'
 import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
 
+/**
+ * Hono middleware that creates a {@link SupabaseContext} and stores it in `c.var.supabaseContext`.
+ *
+ * This is the Hono adapter equivalent of the top-level {@link withSupabase} wrapper.
+ * It handles auth and client creation, then makes the context available to all
+ * downstream handlers via Hono's context variables.
+ *
+ * **Middleware stacking:** If a previous middleware already set `supabaseContext`,
+ * this middleware is skipped. This enables route-level overrides — a route can use
+ * `withSupabase({ allow: 'secret' })` while the app-wide middleware uses
+ * `withSupabase({ allow: 'user' })`, without the app-wide one overwriting
+ * the stricter context.
+ *
+ * **CORS:** The `cors` option from {@link WithSupabaseConfig} is intentionally excluded.
+ * Use Hono's built-in `cors()` middleware instead.
+ *
+ * **Error handling:** On auth failure, throws a Hono `HTTPException` with the
+ * appropriate status code, which Hono converts to an error response.
+ *
+ * @param config - Auth modes and optional environment overrides.
+ *   The `cors` property is omitted — handle CORS with Hono's `cors()` middleware.
+ *
+ * @returns A Hono middleware that sets `c.var.supabaseContext`.
+ *
+ * @example Basic usage — protect all routes
+ * ```ts
+ * import { Hono } from 'hono'
+ * import { withSupabase } from '@supabase/edge-functions/adapters/hono'
+ *
+ * const app = new Hono()
+ *
+ * // Apply to all routes
+ * app.use('*', withSupabase({ allow: 'user' }))
+ *
+ * app.get('/profile', async (c) => {
+ *   const { supabase, userClaims } = c.var.supabaseContext
+ *   const { data } = await supabase.rpc('get_profile')
+ *   return c.json({ profile: data, userId: userClaims!.id })
+ * })
+ *
+ * export default { fetch: app.fetch }
+ * ```
+ *
+ * @example Route-level overrides
+ * ```ts
+ * const app = new Hono()
+ *
+ * // App-wide: require authenticated user
+ * app.use('*', withSupabase({ allow: 'user' }))
+ *
+ * // This route requires a secret key instead
+ * app.post('/webhooks/stripe', withSupabase({ allow: 'secret' }), async (c) => {
+ *   const { supabaseAdmin } = c.var.supabaseContext
+ *   // The route-level middleware ran first, so the app-wide one is skipped
+ *   return c.json({ ok: true })
+ * })
+ * ```
+ *
+ * @example Multiple auth modes
+ * ```ts
+ * app.use('*', withSupabase({ allow: ['user', 'public'] }))
+ *
+ * app.get('/items', async (c) => {
+ *   const { supabase, authType } = c.var.supabaseContext
+ *   // authType is 'user' or 'public' depending on the request
+ *   const { data } = await supabase.rpc('list_items')
+ *   return c.json(data)
+ * })
+ * ```
+ */
 export function withSupabase(config?: Omit<WithSupabaseConfig, 'cors'>) {
   return createMiddleware<{
     Variables: { supabaseContext: SupabaseContext }

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -7,9 +7,11 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
 /**
  * Hono middleware that creates a {@link SupabaseContext} and stores it in `c.var.supabaseContext`.
  *
- * This is the Hono adapter equivalent of the top-level {@link withSupabase} wrapper.
- * It handles auth and client creation, then makes the context available to all
- * downstream handlers via Hono's context variables.
+ * Frameworks like Hono wrap the runtime's native `Request`/`Response` with their
+ * own abstractions (context objects, middleware chains, typed variables). This adapter
+ * bridges that gap — it performs the same auth and client creation as the top-level
+ * {@link withSupabase}, but delivers the result through Hono's context variables
+ * instead of a handler argument.
  *
  * **Middleware stacking:** If a previous middleware already set `supabaseContext`,
  * this middleware is skipped. This enables route-level overrides — a route can use
@@ -31,7 +33,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * @example Basic usage — protect all routes
  * ```ts
  * import { Hono } from 'hono'
- * import { withSupabase } from '@supabase/edge-functions/adapters/hono'
+ * import { withSupabase } from '@supabase/server/adapters/hono'
  *
  * const app = new Hono()
  *

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -4,6 +4,39 @@ import { EnvError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
+/**
+ * Creates an admin Supabase client that bypasses Row-Level Security.
+ *
+ * Uses a secret key for authentication, giving full access to all data.
+ * Use this for operations that legitimately require elevated privileges,
+ * such as writing audit logs, managing user data, or cross-tenant queries.
+ *
+ * Session persistence is disabled since this is designed for stateless
+ * server-side use (one client per request).
+ *
+ * **Security note:** This client bypasses RLS entirely. Never expose it to
+ * end users or use it for operations that should respect user permissions.
+ *
+ * @param env - Optional environment overrides (passed through to {@link resolveEnv}).
+ * @param keyName - Name of the secret key to use (e.g. `"default"`).
+ *   Falls back to `"default"`, then to the first available key.
+ *
+ * @returns A configured {@link SupabaseClient} with admin (service-role) privileges.
+ *
+ * @throws {@link EnvError} If `SUPABASE_URL` is missing or the specified secret key is not found.
+ *
+ * @example
+ * ```ts
+ * import { createAdminClient } from '@supabase/edge-functions/core'
+ *
+ * const supabaseAdmin = createAdminClient()
+ *
+ * // Bypasses RLS — use with care
+ * const { data } = await supabaseAdmin
+ *   .from('audit_log')
+ *   .insert({ action: 'user_login', user_id: userId })
+ * ```
+ */
 export function createAdminClient(
   env?: Partial<SupabaseEnv>,
   keyName?: string | null,

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -27,7 +27,7 @@ import { resolveEnv } from './resolve-env.js'
  *
  * @example
  * ```ts
- * import { createAdminClient } from '@supabase/edge-functions/core'
+ * import { createAdminClient } from '@supabase/server/core'
  *
  * const supabaseAdmin = createAdminClient()
  *

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -4,6 +4,37 @@ import { EnvError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
+/**
+ * Creates a Supabase client scoped to the caller's context.
+ *
+ * The client is configured with a publishable key and (optionally) the caller's
+ * JWT as a Bearer token. This means Row-Level Security policies apply — the client
+ * can only access data the caller is authorized to see.
+ *
+ * Session persistence is disabled since this is designed for stateless
+ * server-side use (one client per request).
+ *
+ * @param token - The caller's JWT. When provided, it's set as the `Authorization`
+ *   header on every request to Supabase. Pass `null` for anonymous access.
+ * @param env - Optional environment overrides (passed through to {@link resolveEnv}).
+ * @param keyName - Name of the publishable key to use (e.g. `"default"`, `"mobile"`).
+ *   Falls back to `"default"`, then to the first available key.
+ *
+ * @returns A configured {@link SupabaseClient} with RLS enforced.
+ *
+ * @throws {@link EnvError} If `SUPABASE_URL` is missing or the specified publishable key is not found.
+ *
+ * @example
+ * ```ts
+ * import { createContextClient, verifyAuth } from '@supabase/edge-functions/core'
+ *
+ * const { data: auth } = await verifyAuth(request, { allow: 'user' })
+ * const supabase = createContextClient(auth.token)
+ *
+ * // RLS policies apply — only returns rows the user can access
+ * const { data } = await supabase.rpc('get_my_items')
+ * ```
+ */
 export function createContextClient(
   token?: string | null,
   env?: Partial<SupabaseEnv>,

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -26,7 +26,7 @@ import { resolveEnv } from './resolve-env.js'
  *
  * @example
  * ```ts
- * import { createContextClient, verifyAuth } from '@supabase/edge-functions/core'
+ * import { createContextClient, verifyAuth } from '@supabase/server/core'
  *
  * const { data: auth } = await verifyAuth(request, { allow: 'user' })
  * const supabase = createContextClient(auth.token)

--- a/src/core/extract-credentials.ts
+++ b/src/core/extract-credentials.ts
@@ -15,7 +15,7 @@ import type { Credentials } from '../types.js'
  *
  * @example
  * ```ts
- * import { extractCredentials } from '@supabase/edge-functions/core'
+ * import { extractCredentials } from '@supabase/server/core'
  *
  * const creds = extractCredentials(request)
  * console.log(creds.token)  // "eyJhbGci..." or null

--- a/src/core/extract-credentials.ts
+++ b/src/core/extract-credentials.ts
@@ -1,5 +1,27 @@
 import type { Credentials } from '../types.js'
 
+/**
+ * Extracts authentication credentials from an incoming HTTP request.
+ *
+ * Reads two headers:
+ * - `Authorization: Bearer <token>` → extracted as `token`
+ * - `apikey: <key>` → extracted as `apikey`
+ *
+ * This is a pure extraction step — no validation or verification is performed.
+ * Pass the result to {@link verifyCredentials} to validate against allowed auth modes.
+ *
+ * @param request - The incoming HTTP request.
+ * @returns The extracted {@link Credentials}. Fields are `null` when the corresponding header is absent.
+ *
+ * @example
+ * ```ts
+ * import { extractCredentials } from '@supabase/edge-functions/core'
+ *
+ * const creds = extractCredentials(request)
+ * console.log(creds.token)  // "eyJhbGci..." or null
+ * console.log(creds.apikey) // "sb-abc123-publishable-..." or null
+ * ```
+ */
 export function extractCredentials(request: Request): Credentials {
   const authHeader = request.headers.get('authorization')
   const token = authHeader?.startsWith('Bearer ')

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,7 @@
-/** Composable primitives for constructing a {@link SupabaseContext}. @packageDocumentation */
+/**
+ * Composable primitives for constructing a {@link SupabaseContext}.
+ * @packageDocumentation
+ */
 
 export { resolveEnv } from './resolve-env.js'
 export { extractCredentials } from './extract-credentials.js'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,9 +1,9 @@
 /**
- * Composable primitives for building custom Supabase auth flows.
+ * Composable primitives for constructing a {@link SupabaseContext}.
  *
  * These are the Layer 2 building blocks that {@link withSupabase} and
  * {@link createSupabaseContext} are built on. Use them when you need
- * fine-grained control over individual steps of the auth pipeline.
+ * fine-grained control over individual steps of the context creation pipeline.
  *
  * **Pipeline order:**
  * 1. {@link resolveEnv} — Read env vars into a {@link SupabaseEnv}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,20 +1,4 @@
-/**
- * Composable primitives for constructing a {@link SupabaseContext}.
- *
- * These are the Layer 2 building blocks that {@link withSupabase} and
- * {@link createSupabaseContext} are built on. Use them when you need
- * fine-grained control over individual steps of the context creation pipeline.
- *
- * **Pipeline order:**
- * 1. {@link resolveEnv} — Read env vars into a {@link SupabaseEnv}
- * 2. {@link extractCredentials} — Pull token + apikey from request headers
- * 3. {@link verifyCredentials} — Validate credentials against allowed auth modes
- * 4. {@link createContextClient} / {@link createAdminClient} — Build Supabase clients
- *
- * Or use {@link verifyAuth} to combine steps 2–3 in a single call.
- *
- * @packageDocumentation
- */
+/** Composable primitives for constructing a {@link SupabaseContext}. @packageDocumentation */
 
 export { resolveEnv } from './resolve-env.js'
 export { extractCredentials } from './extract-credentials.js'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,21 @@
+/**
+ * Composable primitives for building custom Supabase auth flows.
+ *
+ * These are the Layer 2 building blocks that {@link withSupabase} and
+ * {@link createSupabaseContext} are built on. Use them when you need
+ * fine-grained control over individual steps of the auth pipeline.
+ *
+ * **Pipeline order:**
+ * 1. {@link resolveEnv} — Read env vars into a {@link SupabaseEnv}
+ * 2. {@link extractCredentials} — Pull token + apikey from request headers
+ * 3. {@link verifyCredentials} — Validate credentials against allowed auth modes
+ * 4. {@link createContextClient} / {@link createAdminClient} — Build Supabase clients
+ *
+ * Or use {@link verifyAuth} to combine steps 2–3 in a single call.
+ *
+ * @packageDocumentation
+ */
+
 export { resolveEnv } from './resolve-env.js'
 export { extractCredentials } from './extract-credentials.js'
 export { verifyCredentials } from './verify-credentials.js'

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -77,41 +77,21 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | null {
 }
 
 /**
- * Resolves the Supabase environment configuration from environment variables.
+ * Resolves Supabase environment configuration from runtime environment variables.
  *
- * Reads from the following environment variables (works across Deno, Node.js, Bun,
- * and Cloudflare Workers):
+ * Reads `SUPABASE_URL`, keys (`SUPABASE_PUBLISHABLE_KEYS` / `SUPABASE_SECRET_KEYS`),
+ * and `SUPABASE_JWKS`. Works across Deno, Node.js, Bun, and Cloudflare Workers.
  *
- * | Variable                    | Required | Format                                |
- * | --------------------------- | -------- | ------------------------------------- |
- * | `SUPABASE_URL`              | Yes      | `"https://<ref>.supabase.co"`         |
- * | `SUPABASE_PUBLISHABLE_KEYS` | No       | JSON object: `{ "default": "..." }`   |
- * | `SUPABASE_PUBLISHABLE_KEY`  | No       | Single key string (fallback)          |
- * | `SUPABASE_SECRET_KEYS`      | No       | JSON object: `{ "default": "..." }`   |
- * | `SUPABASE_SECRET_KEY`       | No       | Single key string (fallback)          |
- * | `SUPABASE_JWKS`             | No       | JSON — `{ keys: [...] }` or `[...]`   |
- *
- * @param overrides - Partial environment values that take precedence over env vars.
- *   Useful for testing or when env vars aren't available.
- *
- * @returns A result tuple: `{ data, error }`.
- *   - On success: `{ data: SupabaseEnv, error: null }`
- *   - On failure: `{ data: null, error: EnvError }` (currently only when `SUPABASE_URL` is missing)
+ * @param overrides - Partial values that take precedence over env vars.
+ * @returns `{ data: SupabaseEnv, error: null }` on success, `{ data: null, error: EnvError }` on failure.
  *
  * @example
  * ```ts
- * import { resolveEnv } from '@supabase/server/core'
- *
- * // Auto-detect from environment
  * const { data: env, error } = resolveEnv()
  * if (error) throw error
- * console.log(env.url) // "https://abc123.supabase.co"
  *
- * // Override specific values (e.g., in tests)
- * const { data: env } = resolveEnv({
- *   url: 'http://localhost:54321',
- *   secretKeys: { default: 'test-secret-key' },
- * })
+ * // Override for tests
+ * const { data: env } = resolveEnv({ url: 'http://localhost:54321' })
  * ```
  */
 export function resolveEnv(

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -100,7 +100,7 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | null {
  *
  * @example
  * ```ts
- * import { resolveEnv } from '@supabase/edge-functions/core'
+ * import { resolveEnv } from '@supabase/server/core'
  *
  * // Auto-detect from environment
  * const { data: env, error } = resolveEnv()

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -2,7 +2,8 @@ import { EnvError } from '../errors.js'
 import type { JsonWebKeySet, SupabaseEnv } from '../types.js'
 
 /**
- * Reads an environment variable from the current runtime (Deno, Node.js, Bun, or Workers).
+ * Reads an environment variable from the current runtime (Deno, Node.js, or Bun).
+ * Cloudflare Workers require node-compat or passing values via `overrides`.
  * @internal
  */
 function getEnvVar(name: string): string | undefined {
@@ -80,7 +81,8 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | null {
  * Resolves Supabase environment configuration from runtime environment variables.
  *
  * Reads `SUPABASE_URL`, keys (`SUPABASE_PUBLISHABLE_KEYS` / `SUPABASE_SECRET_KEYS`),
- * and `SUPABASE_JWKS`. Works across Deno, Node.js, Bun, and Cloudflare Workers.
+ * and `SUPABASE_JWKS`. Works across Deno, Node.js, and Bun. For Cloudflare Workers,
+ * use `overrides` or enable node-compat.
  *
  * @param overrides - Partial values that take precedence over env vars.
  * @returns `{ data: SupabaseEnv, error: null }` on success, `{ data: null, error: EnvError }` on failure.

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -1,6 +1,10 @@
 import { EnvError } from '../errors.js'
 import type { JsonWebKeySet, SupabaseEnv } from '../types.js'
 
+/**
+ * Reads an environment variable from the current runtime (Deno, Node.js, Bun, or Workers).
+ * @internal
+ */
 function getEnvVar(name: string): string | undefined {
   // Deno runtime
   if (typeof Deno !== 'undefined' && Deno.env?.get) {
@@ -13,6 +17,11 @@ function getEnvVar(name: string): string | undefined {
   return undefined
 }
 
+/**
+ * Parses a JSON string into a `Record<string, string>` key map.
+ * Returns an empty object if the input is missing, malformed, or not a plain object.
+ * @internal
+ */
 function parseKeys(raw: string | undefined): Record<string, string> {
   if (!raw) return {}
   try {
@@ -30,6 +39,12 @@ function parseKeys(raw: string | undefined): Record<string, string> {
   }
 }
 
+/**
+ * Resolves API keys from environment variables. Checks the plural form first
+ * (`SUPABASE_PUBLISHABLE_KEYS` as JSON), then falls back to the singular form
+ * (`SUPABASE_PUBLISHABLE_KEY` stored as `{ default: "<value>" }`).
+ * @internal
+ */
 function resolveKeys(
   singularVar: string,
   pluralVar: string,
@@ -41,6 +56,12 @@ function resolveKeys(
   return {}
 }
 
+/**
+ * Parses a JWKS JSON string into a {@link JsonWebKeySet}.
+ * Accepts both `{ keys: [...] }` and bare `[...]` array formats.
+ * Returns `null` if the input is missing or malformed.
+ * @internal
+ */
 function parseJwks(raw: string | undefined): JsonWebKeySet | null {
   if (!raw) return null
   try {
@@ -55,6 +76,44 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | null {
   }
 }
 
+/**
+ * Resolves the Supabase environment configuration from environment variables.
+ *
+ * Reads from the following environment variables (works across Deno, Node.js, Bun,
+ * and Cloudflare Workers):
+ *
+ * | Variable                    | Required | Format                                |
+ * | --------------------------- | -------- | ------------------------------------- |
+ * | `SUPABASE_URL`              | Yes      | `"https://<ref>.supabase.co"`         |
+ * | `SUPABASE_PUBLISHABLE_KEYS` | No       | JSON object: `{ "default": "..." }`   |
+ * | `SUPABASE_PUBLISHABLE_KEY`  | No       | Single key string (fallback)          |
+ * | `SUPABASE_SECRET_KEYS`      | No       | JSON object: `{ "default": "..." }`   |
+ * | `SUPABASE_SECRET_KEY`       | No       | Single key string (fallback)          |
+ * | `SUPABASE_JWKS`             | No       | JSON — `{ keys: [...] }` or `[...]`   |
+ *
+ * @param overrides - Partial environment values that take precedence over env vars.
+ *   Useful for testing or when env vars aren't available.
+ *
+ * @returns A result tuple: `{ data, error }`.
+ *   - On success: `{ data: SupabaseEnv, error: null }`
+ *   - On failure: `{ data: null, error: EnvError }` (currently only when `SUPABASE_URL` is missing)
+ *
+ * @example
+ * ```ts
+ * import { resolveEnv } from '@supabase/edge-functions/core'
+ *
+ * // Auto-detect from environment
+ * const { data: env, error } = resolveEnv()
+ * if (error) throw error
+ * console.log(env.url) // "https://abc123.supabase.co"
+ *
+ * // Override specific values (e.g., in tests)
+ * const { data: env } = resolveEnv({
+ *   url: 'http://localhost:54321',
+ *   secretKeys: { default: 'test-secret-key' },
+ * })
+ * ```
+ */
 export function resolveEnv(
   overrides?: Partial<SupabaseEnv>,
 ): { data: SupabaseEnv; error: null } | { data: null; error: EnvError } {

--- a/src/core/utils/timing-safe-equal.ts
+++ b/src/core/utils/timing-safe-equal.ts
@@ -1,5 +1,30 @@
 const encoder = new TextEncoder()
 
+/**
+ * Compares two strings in constant time to prevent timing attacks.
+ *
+ * Uses the double-HMAC technique: both strings are HMAC-signed with a random
+ * ephemeral key, then the resulting signatures are compared byte-by-byte.
+ * This ensures the comparison time is independent of where the strings differ,
+ * preventing attackers from inferring key contents through response-time analysis.
+ *
+ * **Why double HMAC?** Direct byte comparison leaks timing information
+ * (it short-circuits on the first mismatch). HMAC produces fixed-length
+ * outputs that are uniformly distributed, so the XOR loop always processes
+ * the same number of bytes regardless of input.
+ *
+ * @param a - First string to compare.
+ * @param b - Second string to compare.
+ * @returns `true` if the strings are equal, `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * // Used internally by verifyCredentials to compare API keys
+ * const isValid = await timingSafeEqual(providedKey, storedKey)
+ * ```
+ *
+ * @internal
+ */
 export async function timingSafeEqual(a: string, b: string): Promise<boolean> {
   const key = crypto.getRandomValues(new Uint8Array(32))
   const cryptoKey = await crypto.subtle.importKey(

--- a/src/core/utils/timing-safe-equal.ts
+++ b/src/core/utils/timing-safe-equal.ts
@@ -2,26 +2,7 @@ const encoder = new TextEncoder()
 
 /**
  * Compares two strings in constant time to prevent timing attacks.
- *
- * Uses the double-HMAC technique: both strings are HMAC-signed with a random
- * ephemeral key, then the resulting signatures are compared byte-by-byte.
- * This ensures the comparison time is independent of where the strings differ,
- * preventing attackers from inferring key contents through response-time analysis.
- *
- * **Why double HMAC?** Direct byte comparison leaks timing information
- * (it short-circuits on the first mismatch). HMAC produces fixed-length
- * outputs that are uniformly distributed, so the XOR loop always processes
- * the same number of bytes regardless of input.
- *
- * @param a - First string to compare.
- * @param b - Second string to compare.
- * @returns `true` if the strings are equal, `false` otherwise.
- *
- * @example
- * ```ts
- * // Used internally by verifyCredentials to compare API keys
- * const isValid = await timingSafeEqual(providedKey, storedKey)
- * ```
+ * Uses the double-HMAC technique with a random ephemeral key.
  *
  * @internal
  */

--- a/src/core/verify-auth.ts
+++ b/src/core/verify-auth.ts
@@ -3,11 +3,50 @@ import type { AllowWithKey, AuthResult, SupabaseEnv } from '../types.js'
 import { extractCredentials } from './extract-credentials.js'
 import { verifyCredentials } from './verify-credentials.js'
 
+/**
+ * Options for {@link verifyAuth}.
+ */
 interface VerifyAuthOptions {
+  /**
+   * Auth mode(s) to try. Modes are attempted in order — the first match wins.
+   *
+   * @see {@link AllowWithKey} for the full syntax including named keys.
+   */
   allow: AllowWithKey | AllowWithKey[]
+
+  /** Optional environment overrides (passed through to {@link resolveEnv}). */
   env?: Partial<SupabaseEnv>
 }
 
+/**
+ * Extracts credentials from a request and verifies them in a single step.
+ *
+ * This is a convenience function that combines {@link extractCredentials} and
+ * {@link verifyCredentials}. Use it when you want the full auth flow without
+ * needing to inspect the raw credentials.
+ *
+ * @param request - The incoming HTTP request.
+ * @param options - Auth modes to accept and optional environment overrides.
+ *
+ * @returns A result tuple: `{ data, error }`.
+ *   - On success: `{ data: AuthResult, error: null }`
+ *   - On failure: `{ data: null, error: AuthError }`
+ *
+ * @example
+ * ```ts
+ * import { verifyAuth } from '@supabase/edge-functions/core'
+ *
+ * const { data: auth, error } = await verifyAuth(request, {
+ *   allow: 'user',
+ * })
+ *
+ * if (error) {
+ *   return Response.json({ error: error.message }, { status: error.status })
+ * }
+ *
+ * console.log(auth.userClaims!.id) // "d0f1a2b3-..."
+ * ```
+ */
 export async function verifyAuth(
   request: Request,
   options: VerifyAuthOptions,

--- a/src/core/verify-auth.ts
+++ b/src/core/verify-auth.ts
@@ -34,7 +34,7 @@ interface VerifyAuthOptions {
  *
  * @example
  * ```ts
- * import { verifyAuth } from '@supabase/edge-functions/core'
+ * import { verifyAuth } from '@supabase/server/core'
  *
  * const { data: auth, error } = await verifyAuth(request, {
  *   allow: 'user',

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -212,7 +212,7 @@ async function tryMode(
  *
  * @example
  * ```ts
- * import { extractCredentials, verifyCredentials } from '@supabase/edge-functions/core'
+ * import { extractCredentials, verifyCredentials } from '@supabase/server/core'
  *
  * const credentials = extractCredentials(request)
  * const { data: auth, error } = await verifyCredentials(credentials, {

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -189,41 +189,22 @@ async function tryMode(
 /**
  * Verifies pre-extracted credentials against one or more allowed auth modes.
  *
- * This is the core verification primitive. It resolves the environment, then tries
- * each allowed mode in order until one matches. Use {@link verifyAuth} if you want
- * to extract and verify in a single call.
- *
- * **Auth mode behavior:**
- *
- * | Mode       | Checks                                  | Result fields populated                |
- * | ---------- | --------------------------------------- | -------------------------------------- |
- * | `"always"` | Nothing — always succeeds               | `authType` only                        |
- * | `"public"` | `apikey` against publishable keys       | `authType`, `keyName`                  |
- * | `"secret"` | `apikey` against secret keys            | `authType`, `keyName`                  |
- * | `"user"`   | Bearer token as JWT (JWKS verification) | `authType`, `token`, `userClaims`, `claims` |
+ * Tries each mode in order — first match wins. Use {@link verifyAuth} to extract
+ * and verify in a single call.
  *
  * @param credentials - The credentials to verify (from {@link extractCredentials}).
- * @param options - Verification options including allowed auth modes and optional env overrides.
- *
- * @returns A result tuple: `{ data, error }`.
- *   - On success: `{ data: AuthResult, error: null }`
- *   - On failure: `{ data: null, error: AuthError }` with status `401` (invalid credentials)
- *     or `500` (env misconfiguration)
+ * @param options - Allowed auth modes and optional env overrides.
+ * @returns `{ data: AuthResult, error: null }` on success, `{ data: null, error: AuthError }` on failure.
  *
  * @example
  * ```ts
- * import { extractCredentials, verifyCredentials } from '@supabase/server/core'
- *
  * const credentials = extractCredentials(request)
  * const { data: auth, error } = await verifyCredentials(credentials, {
  *   allow: ['user', 'public'],
  * })
- *
  * if (error) {
  *   return Response.json({ error: error.message }, { status: error.status })
  * }
- *
- * console.log(auth.authType) // "user" or "public"
  * ```
  */
 export async function verifyCredentials(

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -13,11 +13,33 @@ import type {
 import { timingSafeEqual } from './utils/timing-safe-equal.js'
 import { resolveEnv } from './resolve-env.js'
 
+/**
+ * Options for {@link verifyCredentials}.
+ */
 interface VerifyCredentialsOptions {
+  /**
+   * Auth mode(s) to try. Modes are attempted in order — the first match wins.
+   *
+   * @see {@link AllowWithKey} for the full syntax including named keys.
+   */
   allow: AllowWithKey | AllowWithKey[]
+
+  /** Optional environment overrides (passed through to {@link resolveEnv}). */
   env?: Partial<SupabaseEnv>
 }
 
+/**
+ * Parses an {@link AllowWithKey} string into its base mode and optional key name.
+ *
+ * @example
+ * ```
+ * parseAllowMode('user')         → { base: 'user',   keyName: null }
+ * parseAllowMode('public:web')   → { base: 'public', keyName: 'web' }
+ * parseAllowMode('secret:*')     → { base: 'secret', keyName: '*' }
+ * ```
+ *
+ * @internal
+ */
 function parseAllowMode(mode: AllowWithKey): {
   base: Allow
   keyName: string | null
@@ -37,6 +59,10 @@ function parseAllowMode(mode: AllowWithKey): {
   return { base, keyName }
 }
 
+/**
+ * Converts raw {@link JWTClaims} (snake_case) to a normalized {@link UserClaims} (camelCase).
+ * @internal
+ */
 function claimsToUserClaims(claims: JWTClaims): UserClaims {
   return {
     id: claims.sub,
@@ -47,6 +73,11 @@ function claimsToUserClaims(claims: JWTClaims): UserClaims {
   }
 }
 
+/**
+ * Attempts to authenticate credentials against a single auth mode.
+ * Returns the {@link AuthResult} on success, or `null` if the mode doesn't match.
+ * @internal
+ */
 async function tryMode(
   mode: AllowWithKey,
   credentials: Credentials,
@@ -155,6 +186,46 @@ async function tryMode(
   }
 }
 
+/**
+ * Verifies pre-extracted credentials against one or more allowed auth modes.
+ *
+ * This is the core verification primitive. It resolves the environment, then tries
+ * each allowed mode in order until one matches. Use {@link verifyAuth} if you want
+ * to extract and verify in a single call.
+ *
+ * **Auth mode behavior:**
+ *
+ * | Mode       | Checks                                  | Result fields populated                |
+ * | ---------- | --------------------------------------- | -------------------------------------- |
+ * | `"always"` | Nothing — always succeeds               | `authType` only                        |
+ * | `"public"` | `apikey` against publishable keys       | `authType`, `keyName`                  |
+ * | `"secret"` | `apikey` against secret keys            | `authType`, `keyName`                  |
+ * | `"user"`   | Bearer token as JWT (JWKS verification) | `authType`, `token`, `userClaims`, `claims` |
+ *
+ * @param credentials - The credentials to verify (from {@link extractCredentials}).
+ * @param options - Verification options including allowed auth modes and optional env overrides.
+ *
+ * @returns A result tuple: `{ data, error }`.
+ *   - On success: `{ data: AuthResult, error: null }`
+ *   - On failure: `{ data: null, error: AuthError }` with status `401` (invalid credentials)
+ *     or `500` (env misconfiguration)
+ *
+ * @example
+ * ```ts
+ * import { extractCredentials, verifyCredentials } from '@supabase/edge-functions/core'
+ *
+ * const credentials = extractCredentials(request)
+ * const { data: auth, error } = await verifyCredentials(credentials, {
+ *   allow: ['user', 'public'],
+ * })
+ *
+ * if (error) {
+ *   return Response.json({ error: error.message }, { status: error.status })
+ * }
+ *
+ * console.log(auth.authType) // "user" or "public"
+ * ```
+ */
 export async function verifyCredentials(
   credentials: Credentials,
   options: VerifyCredentialsOptions,

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,13 +1,42 @@
 import { corsHeaders as defaultCorsHeaders } from '@supabase/supabase-js/cors'
 
+/**
+ * CORS configuration for {@link withSupabase}.
+ *
+ * - `true` — uses `@supabase/supabase-js` default CORS headers.
+ * - `false` — disables CORS handling entirely.
+ * - `Record<string, string>` — custom CORS headers to use.
+ *
+ * @internal
+ */
 type CorsConfig = boolean | Record<string, string>
 
+/**
+ * Builds the CORS headers object based on the given configuration.
+ *
+ * @param config - The CORS configuration.
+ * @returns A headers record to include in the response. Empty object if CORS is disabled.
+ *
+ * @internal
+ */
 export function buildCorsHeaders(config?: CorsConfig): Record<string, string> {
   if (config === false) return {}
   if (typeof config === 'object') return config
   return defaultCorsHeaders
 }
 
+/**
+ * Returns a new `Response` with CORS headers appended.
+ *
+ * Creates a clone of the original response and sets each CORS header on it.
+ * If CORS is disabled (`config === false`), returns the original response unchanged.
+ *
+ * @param response - The original response to augment.
+ * @param config - The CORS configuration.
+ * @returns A new `Response` with CORS headers set, or the original response if CORS is disabled.
+ *
+ * @internal
+ */
 export function addCorsHeaders(
   response: Response,
   config?: CorsConfig,

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -4,6 +4,57 @@ import { createAdminClient } from './core/create-admin-client.js'
 import { createContextClient } from './core/create-context-client.js'
 import { verifyAuth } from './core/verify-auth.js'
 
+/**
+ * Creates a {@link SupabaseContext} directly from a request.
+ *
+ * Use this when you need the Supabase context without the full {@link withSupabase}
+ * wrapper — for example, inside framework route handlers, custom middleware, or
+ * test setups where you want explicit control over error handling.
+ *
+ * Performs the same auth + client creation as `withSupabase`, but returns a
+ * result tuple instead of producing a `Response`. You handle errors yourself.
+ *
+ * @param request - The incoming HTTP request.
+ * @param options - Configuration for auth modes, environment overrides, and CORS.
+ *   The `cors` option is ignored here (only relevant in {@link withSupabase}).
+ *
+ * @returns A result tuple: `{ data, error }`.
+ *   - On success: `{ data: SupabaseContext, error: null }`
+ *   - On failure: `{ data: null, error: AuthError }` with an appropriate status code
+ *
+ * @example Basic usage
+ * ```ts
+ * import { createSupabaseContext } from '@supabase/edge-functions'
+ *
+ * const { data: ctx, error } = await createSupabaseContext(request, {
+ *   allow: 'user',
+ * })
+ *
+ * if (error) {
+ *   return Response.json(
+ *     { error: error.message, code: error.code },
+ *     { status: error.status },
+ *   )
+ * }
+ *
+ * // ctx.supabase, ctx.supabaseAdmin, ctx.userClaims are ready
+ * const { data } = await ctx.supabase.rpc('get_my_items')
+ * ```
+ *
+ * @example Inside a framework route handler (e.g., SvelteKit)
+ * ```ts
+ * export async function GET({ request }) {
+ *   const { data: ctx, error } = await createSupabaseContext(request, {
+ *     allow: 'user',
+ *   })
+ *   if (error) {
+ *     return new Response(error.message, { status: error.status })
+ *   }
+ *   const { data } = await ctx.supabase.rpc('get_user_settings')
+ *   return Response.json(data)
+ * }
+ * ```
+ */
 export async function createSupabaseContext(
   request: Request,
   options?: WithSupabaseConfig,

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -24,7 +24,7 @@ import { verifyAuth } from './core/verify-auth.js'
  *
  * @example Basic usage
  * ```ts
- * import { createSupabaseContext } from '@supabase/edge-functions'
+ * import { createSupabaseContext } from '@supabase/server'
  *
  * const { data: ctx, error } = await createSupabaseContext(request, {
  *   allow: 'user',

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-var */
 
+/**
+ * Deno runtime global. Present when running in Supabase Edge Functions
+ * or any Deno environment. Used by {@link resolveEnv} to read environment variables.
+ */
 declare var Deno:
   | {
       env: {
@@ -8,6 +12,10 @@ declare var Deno:
     }
   | undefined
 
+/**
+ * Node.js / Bun / Cloudflare Workers global. Used by {@link resolveEnv}
+ * as a fallback when the Deno global is not available.
+ */
 declare var process:
   | {
       env: Record<string, string | undefined>

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,36 @@
+/**
+ * Thrown when a required environment variable is missing or malformed.
+ *
+ * Has a fixed `status` of `500` since environment errors are server-side
+ * configuration issues, not client errors.
+ *
+ * @example
+ * ```ts
+ * import { EnvError } from '@supabase/edge-functions'
+ *
+ * try {
+ *   const client = createAdminClient()
+ * } catch (e) {
+ *   if (e instanceof EnvError) {
+ *     console.error(`Config issue [${e.code}]: ${e.message}`)
+ *     // → "Config issue [MISSING_SUPABASE_URL]: SUPABASE_URL is required but not set"
+ *   }
+ * }
+ * ```
+ */
 export class EnvError extends Error {
+  /** Always `500` — environment errors are server-side issues. */
   readonly status = 500
+
+  /**
+   * Machine-readable error code.
+   *
+   * Known codes:
+   * - `"MISSING_SUPABASE_URL"` — `SUPABASE_URL` not set
+   * - `"MISSING_PUBLISHABLE_KEY"` — No publishable key found
+   * - `"MISSING_SECRET_KEY"` — No secret key found
+   * - `"ENV_ERROR"` — Generic environment error
+   */
   readonly code: string
 
   constructor(message: string, code = 'ENV_ERROR') {
@@ -9,8 +40,44 @@ export class EnvError extends Error {
   }
 }
 
+/**
+ * Thrown when authentication or authorization fails.
+ *
+ * Carries an HTTP `status` code suitable for returning directly in a response
+ * (typically `401` for invalid credentials, `500` for server-side auth failures).
+ *
+ * @example
+ * ```ts
+ * import { AuthError, createSupabaseContext } from '@supabase/edge-functions'
+ *
+ * const { data: ctx, error } = await createSupabaseContext(request, { allow: 'user' })
+ * if (error) {
+ *   // error is an AuthError
+ *   return Response.json(
+ *     { error: error.message, code: error.code },
+ *     { status: error.status },
+ *   )
+ * }
+ * ```
+ */
 export class AuthError extends Error {
+  /**
+   * HTTP status code.
+   *
+   * - `401` — Invalid or missing credentials
+   * - `500` — Server-side auth failure (e.g., missing JWKS, env misconfiguration)
+   */
   readonly status: number
+
+  /**
+   * Machine-readable error code.
+   *
+   * Known codes:
+   * - `"INVALID_CREDENTIALS"` — No credential matched any allowed auth mode
+   * - `"CLIENT_ERROR"` — Failed to create a Supabase client after auth succeeded
+   * - `"AUTH_ERROR"` — Generic authentication error
+   * - Any `EnvError` code (propagated when env resolution fails during auth)
+   */
   readonly code: string
 
   constructor(message: string, code = 'AUTH_ERROR', status = 401) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { EnvError } from '@supabase/edge-functions'
+ * import { EnvError } from '@supabase/server'
  *
  * try {
  *   const client = createAdminClient()
@@ -48,7 +48,7 @@ export class EnvError extends Error {
  *
  * @example
  * ```ts
- * import { AuthError, createSupabaseContext } from '@supabase/edge-functions'
+ * import { AuthError, createSupabaseContext } from '@supabase/server'
  *
  * const { data: ctx, error } = await createSupabaseContext(request, { allow: 'user' })
  * if (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-/** Server-side Supabase utilities for modern runtimes. @packageDocumentation */
+/**
+ * Server-side Supabase utilities for modern runtimes.
+ * @packageDocumentation
+ */
 
 export { withSupabase } from './with-supabase.js'
 export { createSupabaseContext } from './create-supabase-context.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,38 @@
+/**
+ * `@supabase/edge-functions` — Server-side Supabase utilities for modern runtimes.
+ *
+ * This package provides authentication, client creation, and context injection for
+ * any server-side environment that supports the standard `fetch` handler pattern —
+ * Supabase Edge Functions, Cloudflare Workers, Bun, Deno, and others.
+ *
+ * ## Two-layer architecture
+ *
+ * **Layer 1 — Declarative wrappers** (this module):
+ * - {@link withSupabase} — Wraps a handler with auth + CORS + context creation.
+ * - {@link createSupabaseContext} — Creates a context directly (for frameworks / custom middleware).
+ *
+ * **Layer 2 — Composable primitives** (`@supabase/edge-functions/core`):
+ * - {@link resolveEnv}, {@link extractCredentials}, {@link verifyCredentials},
+ *   {@link verifyAuth}, {@link createContextClient}, {@link createAdminClient}
+ *
+ * Layer 1 is built on Layer 2. Both produce the same {@link SupabaseContext}.
+ *
+ * ## Quick start
+ *
+ * ```ts
+ * import { withSupabase } from '@supabase/edge-functions'
+ *
+ * export default {
+ *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
+ *     const { data } = await ctx.supabase.rpc('get_my_profile')
+ *     return Response.json(data)
+ *   }),
+ * }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
 export { withSupabase } from './with-supabase.js'
 export { createSupabaseContext } from './create-supabase-context.js'
 export { resolveEnv } from './core/resolve-env.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@supabase/edge-functions` — Server-side Supabase utilities for modern runtimes.
+ * `@supabase/server` — Server-side Supabase utilities for modern runtimes.
  *
  * This package provides authentication, client creation, and context injection for
  * any server-side environment that supports the standard `fetch` handler pattern —
@@ -11,7 +11,7 @@
  * - {@link withSupabase} — Wraps a handler with auth + CORS + context creation.
  * - {@link createSupabaseContext} — Creates a context directly (for frameworks / custom middleware).
  *
- * **Layer 2 — Composable primitives** (`@supabase/edge-functions/core`):
+ * **Layer 2 — Composable primitives** (`@supabase/server/core`):
  * - {@link resolveEnv}, {@link extractCredentials}, {@link verifyCredentials},
  *   {@link verifyAuth}, {@link createContextClient}, {@link createAdminClient}
  *
@@ -20,7 +20,7 @@
  * ## Quick start
  *
  * ```ts
- * import { withSupabase } from '@supabase/edge-functions'
+ * import { withSupabase } from '@supabase/server'
  *
  * export default {
  *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,4 @@
-/**
- * `@supabase/server` — Server-side Supabase utilities for modern runtimes.
- *
- * This package provides authentication, client creation, and context injection for
- * any server-side environment that supports the standard `fetch` handler pattern —
- * Supabase Edge Functions, Cloudflare Workers, Bun, Deno, and others.
- *
- * ## Two-layer architecture
- *
- * **Layer 1 — Declarative wrappers** (this module):
- * - {@link withSupabase} — Wraps a handler with auth + CORS + context creation.
- * - {@link createSupabaseContext} — Creates a context directly (for frameworks / custom middleware).
- *
- * **Layer 2 — Composable primitives** (`@supabase/server/core`):
- * - {@link resolveEnv}, {@link extractCredentials}, {@link verifyCredentials},
- *   {@link verifyAuth}, {@link createContextClient}, {@link createAdminClient}
- *
- * Layer 1 is built on Layer 2. Both produce the same {@link SupabaseContext}.
- *
- * ## Quick start
- *
- * ```ts
- * import { withSupabase } from '@supabase/server'
- *
- * export default {
- *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
- *     const { data } = await ctx.supabase.rpc('get_my_profile')
- *     return Response.json(data)
- *   }),
- * }
- * ```
- *
- * @packageDocumentation
- */
+/** Server-side Supabase utilities for modern runtimes. @packageDocumentation */
 
 export { withSupabase } from './with-supabase.js'
 export { createSupabaseContext } from './create-supabase-context.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,64 +1,301 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
+/**
+ * Authentication mode that determines what credentials a request must provide.
+ *
+ * - `"always"` — No credentials required. Every request is accepted.
+ * - `"public"` — Requires a valid publishable key in the `apikey` header.
+ * - `"secret"` — Requires a valid secret key in the `apikey` header (timing-safe comparison).
+ * - `"user"` — Requires a valid JWT in the `Authorization: Bearer <token>` header.
+ *
+ * @example
+ * ```ts
+ * // Single mode
+ * withSupabase({ allow: 'user' }, handler)
+ *
+ * // Multiple modes — the first match wins
+ * withSupabase({ allow: ['user', 'public'] }, handler)
+ * ```
+ */
 export type Allow = 'always' | 'public' | 'secret' | 'user'
+
+/**
+ * Extended auth mode that supports targeting a specific named key.
+ *
+ * Use the colon syntax (`"public:web_app"`) to require a specific named key
+ * from the `SUPABASE_PUBLISHABLE_KEYS` or `SUPABASE_SECRET_KEYS` JSON object.
+ * Use `"public:*"` or `"secret:*"` to accept any key in the set.
+ *
+ * @example
+ * ```ts
+ * // Accept only the "mobile" publishable key
+ * withSupabase({ allow: 'public:mobile' }, handler)
+ *
+ * // Accept any secret key
+ * withSupabase({ allow: 'secret:*' }, handler)
+ *
+ * // Mix named keys with other modes
+ * withSupabase({ allow: ['user', 'public:web_app'] }, handler)
+ * ```
+ */
 export type AllowWithKey = Allow | `public:${string}` | `secret:${string}`
 
+/**
+ * Resolved Supabase environment configuration.
+ *
+ * Holds the project URL, API keys, and JWKS needed by every other primitive.
+ * Typically resolved automatically from environment variables by {@link resolveEnv},
+ * but can be passed explicitly via the `env` option.
+ *
+ * @see {@link resolveEnv} for how each field maps to environment variables.
+ */
 export interface SupabaseEnv {
+  /** Supabase project URL (e.g. `"https://<ref>.supabase.co"`). Sourced from `SUPABASE_URL`. */
   url: string
+
+  /**
+   * Named publishable (anon) keys. Sourced from `SUPABASE_PUBLISHABLE_KEYS` (JSON object)
+   * or `SUPABASE_PUBLISHABLE_KEY` (single key, stored as `{ default: "<value>" }`).
+   */
   publishableKeys: Record<string, string>
+
+  /**
+   * Named secret (service-role) keys. Sourced from `SUPABASE_SECRET_KEYS` (JSON object)
+   * or `SUPABASE_SECRET_KEY` (single key, stored as `{ default: "<value>" }`).
+   */
   secretKeys: Record<string, string>
+
+  /**
+   * JSON Web Key Set used for JWT verification. Sourced from `SUPABASE_JWKS`.
+   * Accepts both `{ keys: [...] }` and bare `[...]` array formats.
+   * `null` when no JWKS is configured (JWT verification will be unavailable).
+   */
   jwks: JsonWebKeySet | null
 }
 
+/**
+ * A JSON Web Key Set as defined by RFC 7517.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7517
+ */
 export interface JsonWebKeySet {
+  /** Array of JSON Web Keys. */
   keys: JsonWebKey[]
 }
 
+/**
+ * Raw credentials extracted from an incoming HTTP request.
+ *
+ * Produced by {@link extractCredentials} from the `Authorization` and `apikey` headers.
+ *
+ * @see {@link extractCredentials}
+ */
 export interface Credentials {
+  /** Bearer token from the `Authorization: Bearer <token>` header, or `null` if absent. */
   token: string | null
+
+  /** API key from the `apikey` header, or `null` if absent. */
   apikey: string | null
 }
 
+/**
+ * Result of credential verification.
+ *
+ * Contains the resolved auth mode, the verified token (for `"user"` mode),
+ * decoded JWT claims, and the matched key name (for `"public"` / `"secret"` modes).
+ *
+ * @see {@link verifyCredentials}
+ * @see {@link verifyAuth}
+ */
 export interface AuthResult {
+  /** The auth mode that was successfully matched. */
   authType: Allow
+
+  /** The verified JWT, or `null` for non-user auth modes. */
   token: string | null
+
+  /** Normalized user identity derived from the JWT, or `null` when no JWT is present. */
   userClaims: UserClaims | null
+
+  /** Raw JWT payload, or `null` when no JWT is present. */
   claims: JWTClaims | null
+
+  /** Name of the matched key (e.g. `"default"`, `"mobile"`), or `null` for `"user"` / `"always"` modes. */
   keyName?: string | null
 }
 
+/**
+ * Standard JWT claims as defined by RFC 7519, extended with Supabase-specific fields.
+ *
+ * This is the raw JWT payload — use {@link UserClaims} for a normalized, camelCase view.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+ */
 export interface JWTClaims {
+  /** Subject — the user's unique ID. */
   sub: string
+
+  /** Issuer — typically your Supabase project URL. */
   iss?: string
+
+  /** Audience — who the token is intended for. */
   aud?: string | string[]
+
+  /** Expiration time (seconds since epoch). */
   exp?: number
+
+  /** Issued at (seconds since epoch). */
   iat?: number
+
+  /** Supabase role (e.g. `"authenticated"`, `"anon"`). */
   role?: string
+
+  /** User's email address from Supabase Auth. */
   email?: string
+
+  /** Application-level metadata set via Supabase Auth admin APIs. */
   app_metadata?: Record<string, unknown>
+
+  /** User-editable metadata set via Supabase Auth. */
   user_metadata?: Record<string, unknown>
+
+  /** Additional custom claims. */
   [key: string]: unknown
 }
 
+/**
+ * Normalized, camelCase view of the authenticated user's identity.
+ *
+ * Derived from {@link JWTClaims}. For the full Supabase `User` object
+ * (including email confirmation status, providers, etc.), call
+ * `supabase.auth.getUser()` using the context client.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
+ *     // Quick access — no network call
+ *     const userId = ctx.userClaims!.id
+ *
+ *     // Full user object — requires a network call
+ *     const { data: { user } } = await ctx.supabase.auth.getUser()
+ *     return Response.json({ userId, email: user?.email })
+ *   }),
+ * }
+ * ```
+ */
 export interface UserClaims {
+  /** User's unique ID (same as `JWTClaims.sub`). */
   id: string
+
+  /** Supabase role (e.g. `"authenticated"`). */
   role?: string
+
+  /** User's email address. */
   email?: string
+
+  /** Application-level metadata (e.g. roles, permissions). */
   appMetadata?: Record<string, unknown>
+
+  /** User-editable profile metadata (e.g. display name, avatar). */
   userMetadata?: Record<string, unknown>
 }
 
+/**
+ * Configuration for {@link withSupabase} and {@link createSupabaseContext}.
+ *
+ * Controls which auth modes are accepted, environment overrides, and CORS behavior.
+ *
+ * @example
+ * ```ts
+ * // Require authenticated users, auto-CORS enabled (default)
+ * const config: WithSupabaseConfig = { allow: 'user' }
+ *
+ * // Accept users or service-to-service calls, custom CORS headers
+ * const config: WithSupabaseConfig = {
+ *   allow: ['user', 'secret'],
+ *   cors: { 'Access-Control-Allow-Origin': 'https://myapp.com' },
+ * }
+ *
+ * // No auth required, CORS disabled
+ * const config: WithSupabaseConfig = { allow: 'always', cors: false }
+ * ```
+ */
 export interface WithSupabaseConfig {
+  /**
+   * Auth mode(s) to accept. Modes are tried in order — the first match wins.
+   *
+   * @defaultValue `"user"`
+   */
   allow?: AllowWithKey | AllowWithKey[]
+
+  /**
+   * Override auto-detected environment variables. Useful for testing
+   * or when running in environments without standard env var support.
+   */
   env?: Partial<SupabaseEnv>
+
+  /**
+   * CORS configuration for the `withSupabase` wrapper.
+   *
+   * - `true` (default) — uses `@supabase/supabase-js` default CORS headers.
+   * - `false` — disables CORS handling entirely.
+   * - `Record<string, string>` — custom CORS headers.
+   *
+   * @remarks Only applies to the top-level {@link withSupabase} wrapper.
+   * The Hono adapter handles CORS separately via Hono's own middleware.
+   *
+   * @defaultValue `true`
+   */
   cors?: boolean | Record<string, string>
 }
 
+/**
+ * The Supabase context created for each authenticated request.
+ *
+ * This is the main object your handler receives. It contains pre-configured
+ * Supabase clients and the caller's identity.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
+ *     // RLS-scoped client — respects the caller's permissions
+ *     const { data } = await ctx.supabase.rpc('get_my_items')
+ *
+ *     // Admin client — bypasses RLS for elevated operations
+ *     await ctx.supabaseAdmin.from('audit_log').insert({ user_id: ctx.userClaims!.id })
+ *
+ *     return Response.json(data)
+ *   }),
+ * }
+ * ```
+ */
 export interface SupabaseContext {
+  /**
+   * Supabase client scoped to the caller's identity.
+   *
+   * For `"user"` auth, the client carries the user's JWT so RLS policies apply.
+   * For `"public"` auth, it uses the matched publishable key.
+   * For `"always"` auth, it uses the default publishable key with no JWT.
+   */
   supabase: SupabaseClient
+
+  /**
+   * Admin Supabase client that bypasses Row-Level Security.
+   *
+   * Uses a secret key, so it has full access to all data. Use sparingly
+   * and only for operations that legitimately require elevated privileges
+   * (e.g., writing audit logs, cross-tenant queries).
+   */
   supabaseAdmin: SupabaseClient
+
   /** JWT-derived identity. For the full Supabase User object, call `supabase.auth.getUser()`. */
   userClaims: UserClaims | null
+
+  /** Raw JWT payload. `null` for non-user auth modes. */
   claims: JWTClaims | null
+
+  /** The auth mode that was used for this request. */
   authType: Allow
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,20 +169,6 @@ export interface JWTClaims {
  * Derived from {@link JWTClaims}. For the full Supabase `User` object
  * (including email confirmation status, providers, etc.), call
  * `supabase.auth.getUser()` using the context client.
- *
- * @example
- * ```ts
- * export default {
- *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
- *     // Quick access — no network call
- *     const userId = ctx.userClaims!.id
- *
- *     // Full user object — requires a network call
- *     const { data: { user } } = await ctx.supabase.auth.getUser()
- *     return Response.json({ userId, email: user?.email })
- *   }),
- * }
- * ```
  */
 export interface UserClaims {
   /** User's unique ID (same as `JWTClaims.sub`). */
@@ -253,41 +239,14 @@ export interface WithSupabaseConfig {
 /**
  * The Supabase context created for each authenticated request.
  *
- * This is the main object your handler receives. It contains pre-configured
- * Supabase clients and the caller's identity.
- *
- * @example
- * ```ts
- * export default {
- *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
- *     // RLS-scoped client — respects the caller's permissions
- *     const { data } = await ctx.supabase.rpc('get_my_items')
- *
- *     // Admin client — bypasses RLS for elevated operations
- *     await ctx.supabaseAdmin.from('audit_log').insert({ user_id: ctx.userClaims!.id })
- *
- *     return Response.json(data)
- *   }),
- * }
- * ```
+ * Contains pre-configured Supabase clients and the caller's identity.
+ * Identical regardless of which layer or adapter produced it.
  */
 export interface SupabaseContext {
-  /**
-   * Supabase client scoped to the caller's identity.
-   *
-   * For `"user"` auth, the client carries the user's JWT so RLS policies apply.
-   * For `"public"` auth, it uses the matched publishable key.
-   * For `"always"` auth, it uses the default publishable key with no JWT.
-   */
+  /** Supabase client scoped to the caller's identity. RLS policies apply. */
   supabase: SupabaseClient
 
-  /**
-   * Admin Supabase client that bypasses Row-Level Security.
-   *
-   * Uses a secret key, so it has full access to all data. Use sparingly
-   * and only for operations that legitimately require elevated privileges
-   * (e.g., writing audit logs, cross-tenant queries).
-   */
+  /** Admin Supabase client that bypasses Row-Level Security. */
   supabaseAdmin: SupabaseClient
 
   /** JWT-derived identity. For the full Supabase User object, call `supabase.auth.getUser()`. */

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -5,8 +5,9 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 /**
  * Wraps a request handler with Supabase auth, client creation, and CORS handling.
  *
- * This is the **primary entry point** for server-side Supabase integration. It handles
- * the full lifecycle of an authenticated request:
+ * Built for the Web API `Request`/`Response` standard, which all modern runtimes
+ * (Supabase Edge Functions, Cloudflare Workers, Deno, Bun) implement natively.
+ * It handles the full lifecycle of an authenticated request:
  *
  * 1. **CORS** — Responds to `OPTIONS` preflight requests automatically (unless disabled).
  * 2. **Auth** — Extracts and verifies credentials based on the configured `allow` modes.
@@ -28,7 +29,7 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
  *
  * @example Basic usage — authenticated users only (default)
  * ```ts
- * import { withSupabase } from '@supabase/edge-functions'
+ * import { withSupabase } from '@supabase/server'
  *
  * export default {
  *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -2,6 +2,90 @@ import { buildCorsHeaders, addCorsHeaders } from './cors.js'
 import { createSupabaseContext } from './create-supabase-context.js'
 import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 
+/**
+ * Wraps a request handler with Supabase auth, client creation, and CORS handling.
+ *
+ * This is the **primary entry point** for server-side Supabase integration. It handles
+ * the full lifecycle of an authenticated request:
+ *
+ * 1. **CORS** — Responds to `OPTIONS` preflight requests automatically (unless disabled).
+ * 2. **Auth** — Extracts and verifies credentials based on the configured `allow` modes.
+ * 3. **Context** — Creates RLS-scoped and admin Supabase clients.
+ * 4. **Handler** — Calls your function with the request and {@link SupabaseContext}.
+ * 5. **CORS headers** — Appends CORS headers to the response.
+ *
+ * If authentication fails, returns a JSON error response with the appropriate HTTP status
+ * code — your handler is never called.
+ *
+ * @param config - Controls auth modes, CORS, and environment overrides.
+ *   See {@link WithSupabaseConfig} for all options.
+ * @param handler - Your request handler. Receives the original `Request` and a
+ *   fully-initialized {@link SupabaseContext}.
+ *
+ * @returns A `(req: Request) => Promise<Response>` function compatible with any
+ *   runtime that supports the standard `fetch` handler pattern — Supabase Edge Functions,
+ *   Cloudflare Workers, Bun, Deno, and others.
+ *
+ * @example Basic usage — authenticated users only (default)
+ * ```ts
+ * import { withSupabase } from '@supabase/edge-functions'
+ *
+ * export default {
+ *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
+ *     const { data } = await ctx.supabase.rpc('get_my_profile')
+ *     return Response.json(data)
+ *   }),
+ * }
+ * ```
+ *
+ * @example Multiple auth modes — users or service-to-service
+ * ```ts
+ * export default {
+ *   fetch: withSupabase(
+ *     { allow: ['user', 'secret'] },
+ *     async (req, ctx) => {
+ *       if (ctx.authType === 'user') {
+ *         // Handle user request with RLS
+ *         const { data } = await ctx.supabase.rpc('get_my_items')
+ *         return Response.json(data)
+ *       }
+ *       // Handle service-to-service request with admin access
+ *       const { data } = await ctx.supabaseAdmin.from('items').select()
+ *       return Response.json(data)
+ *     },
+ *   ),
+ * }
+ * ```
+ *
+ * @example Public endpoint — no auth required
+ * ```ts
+ * export default {
+ *   fetch: withSupabase({ allow: 'always' }, async (req, ctx) => {
+ *     const { data } = await ctx.supabase.rpc('get_public_stats')
+ *     return Response.json(data)
+ *   }),
+ * }
+ * ```
+ *
+ * @example Custom CORS headers
+ * ```ts
+ * export default {
+ *   fetch: withSupabase(
+ *     {
+ *       allow: 'user',
+ *       cors: {
+ *         'Access-Control-Allow-Origin': 'https://myapp.com',
+ *         'Access-Control-Allow-Methods': 'GET, POST',
+ *         'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
+ *       },
+ *     },
+ *     async (req, ctx) => {
+ *       return Response.json({ ok: true })
+ *     },
+ *   ),
+ * }
+ * ```
+ */
 export function withSupabase(
   config: WithSupabaseConfig,
   handler: (req: Request, ctx: SupabaseContext) => Promise<Response>,

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -5,29 +5,15 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 /**
  * Wraps a request handler with Supabase auth, client creation, and CORS handling.
  *
- * Built for the Web API `Request`/`Response` standard, which all modern runtimes
- * (Supabase Edge Functions, Cloudflare Workers, Deno, Bun) implement natively.
- * It handles the full lifecycle of an authenticated request:
+ * Built for the Web API `Request`/`Response` standard that all modern runtimes
+ * implement natively. Handles CORS preflight, credential verification,
+ * context creation, and error responses. Your handler only runs on successful auth.
  *
- * 1. **CORS** — Responds to `OPTIONS` preflight requests automatically (unless disabled).
- * 2. **Auth** — Extracts and verifies credentials based on the configured `allow` modes.
- * 3. **Context** — Creates RLS-scoped and admin Supabase clients.
- * 4. **Handler** — Calls your function with the request and {@link SupabaseContext}.
- * 5. **CORS headers** — Appends CORS headers to the response.
+ * @param config - Auth modes, CORS, and environment overrides. See {@link WithSupabaseConfig}.
+ * @param handler - Receives the `Request` and a fully-initialized {@link SupabaseContext}.
+ * @returns A `(req: Request) => Promise<Response>` fetch handler.
  *
- * If authentication fails, returns a JSON error response with the appropriate HTTP status
- * code — your handler is never called.
- *
- * @param config - Controls auth modes, CORS, and environment overrides.
- *   See {@link WithSupabaseConfig} for all options.
- * @param handler - Your request handler. Receives the original `Request` and a
- *   fully-initialized {@link SupabaseContext}.
- *
- * @returns A `(req: Request) => Promise<Response>` function compatible with any
- *   runtime that supports the standard `fetch` handler pattern — Supabase Edge Functions,
- *   Cloudflare Workers, Bun, Deno, and others.
- *
- * @example Basic usage — authenticated users only (default)
+ * @example
  * ```ts
  * import { withSupabase } from '@supabase/server'
  *
@@ -36,54 +22,6 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
  *     const { data } = await ctx.supabase.rpc('get_my_profile')
  *     return Response.json(data)
  *   }),
- * }
- * ```
- *
- * @example Multiple auth modes — users or service-to-service
- * ```ts
- * export default {
- *   fetch: withSupabase(
- *     { allow: ['user', 'secret'] },
- *     async (req, ctx) => {
- *       if (ctx.authType === 'user') {
- *         // Handle user request with RLS
- *         const { data } = await ctx.supabase.rpc('get_my_items')
- *         return Response.json(data)
- *       }
- *       // Handle service-to-service request with admin access
- *       const { data } = await ctx.supabaseAdmin.from('items').select()
- *       return Response.json(data)
- *     },
- *   ),
- * }
- * ```
- *
- * @example Public endpoint — no auth required
- * ```ts
- * export default {
- *   fetch: withSupabase({ allow: 'always' }, async (req, ctx) => {
- *     const { data } = await ctx.supabase.rpc('get_public_stats')
- *     return Response.json(data)
- *   }),
- * }
- * ```
- *
- * @example Custom CORS headers
- * ```ts
- * export default {
- *   fetch: withSupabase(
- *     {
- *       allow: 'user',
- *       cors: {
- *         'Access-Control-Allow-Origin': 'https://myapp.com',
- *         'Access-Control-Allow-Methods': 'GET, POST',
- *         'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
- *       },
- *     },
- *     async (req, ctx) => {
- *       return Response.json({ ok: true })
- *     },
- *   ),
  * }
  * ```
  */

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -1,1 +1,7 @@
+/**
+ * Higher-level wrappers for common server-side patterns.
+ *
+ * @packageDocumentation
+ */
+
 export { verifyWebhookSignature } from './webhook.js'

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -1,7 +1,3 @@
-/**
- * Higher-level wrappers for common server-side patterns.
- *
- * @packageDocumentation
- */
+/** Higher-level wrappers for common server-side patterns. @packageDocumentation */
 
 export { verifyWebhookSignature } from './webhook.js'

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -1,3 +1,6 @@
-/** Higher-level wrappers for common server-side patterns. @packageDocumentation */
+/**
+ * Higher-level wrappers for common server-side patterns.
+ * @packageDocumentation
+ */
 
 export { verifyWebhookSignature } from './webhook.js'

--- a/src/wrappers/webhook.ts
+++ b/src/wrappers/webhook.ts
@@ -1,5 +1,49 @@
 const encoder = new TextEncoder()
 
+/**
+ * Verifies a webhook signature using HMAC-SHA256.
+ *
+ * Computes the expected signature from the payload and shared secret, then
+ * compares it to the provided signature using a timing-safe double-HMAC technique
+ * to prevent timing attacks.
+ *
+ * **How it works:**
+ * 1. Computes `HMAC-SHA256(secret, payload)` → expected signature (hex).
+ * 2. Signs both the expected and provided signatures with a random ephemeral key.
+ * 3. Compares the two HMACs byte-by-byte in constant time.
+ *
+ * @param payload - The raw request body as a string.
+ * @param signature - The hex-encoded signature from the webhook header
+ *   (e.g., from `X-Webhook-Signature` or `X-Hub-Signature-256`).
+ * @param secret - The shared secret used to sign webhooks.
+ *
+ * @returns `true` if the signature is valid, `false` otherwise.
+ *
+ * @example Verify a webhook from an external service
+ * ```ts
+ * import { withSupabase } from '@supabase/edge-functions'
+ * import { verifyWebhookSignature } from '@supabase/edge-functions/wrappers'
+ *
+ * export default {
+ *   fetch: withSupabase({ allow: 'always' }, async (req, ctx) => {
+ *     const payload = await req.text()
+ *     const signature = req.headers.get('x-webhook-signature') ?? ''
+ *     const secret = process.env.WEBHOOK_SECRET!
+ *
+ *     const isValid = await verifyWebhookSignature(payload, signature, secret)
+ *     if (!isValid) {
+ *       return Response.json({ error: 'Invalid signature' }, { status: 401 })
+ *     }
+ *
+ *     // Process the verified webhook payload
+ *     const event = JSON.parse(payload)
+ *     await ctx.supabaseAdmin.from('webhook_events').insert(event)
+ *
+ *     return Response.json({ received: true })
+ *   }),
+ * }
+ * ```
+ */
 export async function verifyWebhookSignature(
   payload: string,
   signature: string,

--- a/src/wrappers/webhook.ts
+++ b/src/wrappers/webhook.ts
@@ -1,46 +1,21 @@
 const encoder = new TextEncoder()
 
 /**
- * Verifies a webhook signature using HMAC-SHA256.
- *
- * Computes the expected signature from the payload and shared secret, then
- * compares it to the provided signature using a timing-safe double-HMAC technique
- * to prevent timing attacks.
- *
- * **How it works:**
- * 1. Computes `HMAC-SHA256(secret, payload)` → expected signature (hex).
- * 2. Signs both the expected and provided signatures with a random ephemeral key.
- * 3. Compares the two HMACs byte-by-byte in constant time.
+ * Verifies a webhook signature using HMAC-SHA256 with timing-safe comparison.
  *
  * @param payload - The raw request body as a string.
- * @param signature - The hex-encoded signature from the webhook header
- *   (e.g., from `X-Webhook-Signature` or `X-Hub-Signature-256`).
+ * @param signature - The hex-encoded signature from the webhook header.
  * @param secret - The shared secret used to sign webhooks.
- *
  * @returns `true` if the signature is valid, `false` otherwise.
  *
- * @example Verify a webhook from an external service
+ * @example
  * ```ts
- * import { withSupabase } from '@supabase/server'
- * import { verifyWebhookSignature } from '@supabase/server/wrappers'
+ * const payload = await req.text()
+ * const signature = req.headers.get('x-webhook-signature') ?? ''
  *
- * export default {
- *   fetch: withSupabase({ allow: 'always' }, async (req, ctx) => {
- *     const payload = await req.text()
- *     const signature = req.headers.get('x-webhook-signature') ?? ''
- *     const secret = process.env.WEBHOOK_SECRET!
- *
- *     const isValid = await verifyWebhookSignature(payload, signature, secret)
- *     if (!isValid) {
- *       return Response.json({ error: 'Invalid signature' }, { status: 401 })
- *     }
- *
- *     // Process the verified webhook payload
- *     const event = JSON.parse(payload)
- *     await ctx.supabaseAdmin.from('webhook_events').insert(event)
- *
- *     return Response.json({ received: true })
- *   }),
+ * const isValid = await verifyWebhookSignature(payload, signature, secret)
+ * if (!isValid) {
+ *   return Response.json({ error: 'Invalid signature' }, { status: 401 })
  * }
  * ```
  */

--- a/src/wrappers/webhook.ts
+++ b/src/wrappers/webhook.ts
@@ -21,8 +21,8 @@ const encoder = new TextEncoder()
  *
  * @example Verify a webhook from an external service
  * ```ts
- * import { withSupabase } from '@supabase/edge-functions'
- * import { verifyWebhookSignature } from '@supabase/edge-functions/wrappers'
+ * import { withSupabase } from '@supabase/server'
+ * import { verifyWebhookSignature } from '@supabase/server/wrappers'
  *
  * export default {
  *   fetch: withSupabase({ allow: 'always' }, async (req, ctx) => {


### PR DESCRIPTION
## Summary
- Adds comprehensive TSDoc documentation to all 19 source files (955 lines)
- Every exported function, type, interface, and error class now has `@param`, `@returns`, `@throws`, `@example`, and `@see` annotations
- All code examples use the runtime-agnostic `export default { fetch }` pattern instead of Deno-specific APIs
- Module-level `@packageDocumentation` overviews on all barrel files

## Test plan
- [x] `pnpm build` passes — doc comments flow through to `.d.mts` / `.d.cts` declaration files
- [x] All 105 tests pass — no behavioral changes
- [x] Verify hover tooltips render correctly in VS Code / IDE