### PR TITLE
feat: passing down Database generic type to `createClient`

### DIFF
--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -4,10 +4,10 @@ import { EnvError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
-export function createAdminClient(
+export function createAdminClient<Database = any>(
   env?: Partial<SupabaseEnv>,
   keyName?: string | null,
-): SupabaseClient {
+): SupabaseClient<Database> {
   const { data: resolved, error } = resolveEnv(env)
   if (error) throw error
 

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -4,7 +4,7 @@ import { EnvError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
-export function createAdminClient<Database = any>(
+export function createAdminClient<Database = unknown>(
   env?: Partial<SupabaseEnv>,
   keyName?: string | null,
 ): SupabaseClient<Database> {

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -4,11 +4,11 @@ import { EnvError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
-export function createContextClient(
+export function createContextClient<Database = any>(
   token?: string | null,
   env?: Partial<SupabaseEnv>,
   keyName?: string | null,
-): SupabaseClient {
+): SupabaseClient<Database> {
   const { data: resolved, error } = resolveEnv(env)
   if (error) throw error
 

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -4,7 +4,7 @@ import { EnvError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
-export function createContextClient<Database = any>(
+export function createContextClient<Database = unknown>(
   token?: string | null,
   env?: Partial<SupabaseEnv>,
   keyName?: string | null,

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -4,7 +4,7 @@ import { createAdminClient } from './core/create-admin-client.js'
 import { createContextClient } from './core/create-context-client.js'
 import { verifyAuth } from './core/verify-auth.js'
 
-export async function createSupabaseContext<Database = any>(
+export async function createSupabaseContext<Database = unknown>(
   request: Request,
   options?: WithSupabaseConfig,
 ): Promise<

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -4,11 +4,12 @@ import { createAdminClient } from './core/create-admin-client.js'
 import { createContextClient } from './core/create-context-client.js'
 import { verifyAuth } from './core/verify-auth.js'
 
-export async function createSupabaseContext(
+export async function createSupabaseContext<Database = any>(
   request: Request,
   options?: WithSupabaseConfig,
 ): Promise<
-  { data: SupabaseContext; error: null } | { data: null; error: AuthError }
+  | { data: SupabaseContext<Database>; error: null }
+  | { data: null; error: AuthError }
 > {
   const allow = options?.allow ?? 'user'
 
@@ -21,9 +22,16 @@ export async function createSupabaseContext(
   }
 
   try {
-    const supabase = createContextClient(auth.token, options?.env, auth.keyName)
+    const supabase = createContextClient<Database>(
+      auth.token,
+      options?.env,
+      auth.keyName,
+    )
     const adminKeyName = auth.authType === 'secret' ? auth.keyName : undefined
-    const supabaseAdmin = createAdminClient(options?.env, adminKeyName)
+    const supabaseAdmin = createAdminClient<Database>(
+      options?.env,
+      adminKeyName,
+    )
 
     return {
       data: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,9 @@ export interface WithSupabaseConfig {
   cors?: boolean | Record<string, string>
 }
 
-export interface SupabaseContext {
-  supabase: SupabaseClient
-  supabaseAdmin: SupabaseClient
+export interface SupabaseContext<Database = any> {
+  supabase: SupabaseClient<Database>
+  supabaseAdmin: SupabaseClient<Database>
   /** JWT-derived identity. For the full Supabase User object, call `supabase.auth.getUser()`. */
   userClaims: UserClaims | null
   claims: JWTClaims | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export interface WithSupabaseConfig {
   cors?: boolean | Record<string, string>
 }
 
-export interface SupabaseContext<Database = any> {
+export interface SupabaseContext<Database = unknown> {
   supabase: SupabaseClient<Database>
   supabaseAdmin: SupabaseClient<Database>
   /** JWT-derived identity. For the full Supabase User object, call `supabase.auth.getUser()`. */

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -2,9 +2,9 @@ import { buildCorsHeaders, addCorsHeaders } from './cors.js'
 import { createSupabaseContext } from './create-supabase-context.js'
 import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 
-export function withSupabase(
+export function withSupabase<Database = any>(
   config: WithSupabaseConfig,
-  handler: (req: Request, ctx: SupabaseContext) => Promise<Response>,
+  handler: (req: Request, ctx: SupabaseContext<Database>) => Promise<Response>,
 ): (req: Request) => Promise<Response> {
   return async (req: Request) => {
     if (config.cors !== false && req.method === 'OPTIONS') {
@@ -14,7 +14,10 @@ export function withSupabase(
       })
     }
 
-    const { data: ctx, error } = await createSupabaseContext(req, config)
+    const { data: ctx, error } = await createSupabaseContext<Database>(
+      req,
+      config,
+    )
     if (error) {
       return Response.json(
         { error: error.message, code: error.code },

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -2,7 +2,7 @@ import { buildCorsHeaders, addCorsHeaders } from './cors.js'
 import { createSupabaseContext } from './create-supabase-context.js'
 import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 
-export function withSupabase<Database = any>(
+export function withSupabase<Database = unknown>(
   config: WithSupabaseConfig,
   handler: (req: Request, ctx: SupabaseContext<Database>) => Promise<Response>,
 ): (req: Request) => Promise<Response> {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Currently there's no way to get Database schema types on `ctx`

## What is the new behavior?

Accepting generics and passing down the database type to `createClient`

## Additional context

<details>

https://github.com/user-attachments/assets/3addb23e-8b50-4aef-8615-bf90825083c8

</details>

