### PR TITLE
fix: removing `core` lib exports from root index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,7 @@
 
 export { withSupabase } from './with-supabase.js'
 export { createSupabaseContext } from './create-supabase-context.js'
-export { resolveEnv } from './core/resolve-env.js'
-export { extractCredentials } from './core/extract-credentials.js'
-export { verifyCredentials } from './core/verify-credentials.js'
-export { verifyAuth } from './core/verify-auth.js'
-export { createContextClient } from './core/create-context-client.js'
-export { createAdminClient } from './core/create-admin-client.js'
+
 export type {
   Allow,
   AllowWithKey,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`core` lib exports are available from package root `@supabase/server`

## What is the new behavior?

`core` lib exports are only available from `@supabase/server/core`

## Additional context

Towards FUNC-528
