### PR TITLE
feat: standardize error response

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Extracts credentials from a Request and validates against the allow config.
 ```ts
 const { data: auth, error } = await verifyAuth(req, { allow: 'user' })
 if (error) {
-  return Response.json({ error: error.message }, { status: error.status })
+  return Response.json({ message: error.message }, { status: error.status })
 }
 ```
 
@@ -246,7 +246,10 @@ export default {
     if (url.pathname === '/todos') {
       const { data: auth, error } = await verifyAuth(req, { allow: 'user' })
       if (error)
-        return Response.json({ error: error.message }, { status: error.status })
+        return Response.json(
+          { message: error.message },
+          { status: error.status },
+        )
 
       const supabase = createContextClient(auth.token)
       const { data } = await supabase.from('todos').select()

--- a/src/core/create-admin-client.test.ts
+++ b/src/core/create-admin-client.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { EnvError } from '../errors.js'
+import {
+  EnvError,
+  MissingDefaultSecretKeyError,
+  MissingSecretKeyError,
+} from '../errors.js'
 import { createAdminClient } from './create-admin-client.js'
 
 const validEnv = {
@@ -46,7 +50,7 @@ describe('createAdminClient', () => {
       })
     } catch (e) {
       expect(e).toBeInstanceOf(EnvError)
-      expect((e as EnvError).code).toBe('MISSING_SECRET_KEY')
+      expect((e as EnvError).code).toBe(MissingDefaultSecretKeyError)
     }
   })
 
@@ -72,7 +76,7 @@ describe('createAdminClient', () => {
       createAdminClient(validEnv, 'nonexistent')
     } catch (e) {
       expect(e).toBeInstanceOf(EnvError)
-      expect((e as EnvError).code).toBe('MISSING_SECRET_KEY')
+      expect((e as EnvError).code).toBe(MissingSecretKeyError)
     }
   })
 

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -1,6 +1,10 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-import { EnvError, MissingSecretKeyError } from '../errors.js'
+import {
+  EnvError,
+  MissingDefaultSecretKeyError,
+  MissingSecretKeyError,
+} from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
@@ -33,11 +37,18 @@ export function createAdminClient<Database = unknown>(
   const secretKey =
     keys[name] ?? (keyName == null ? Object.values(keys)[0] : undefined)
   if (!secretKey) {
-    const msg =
+    const error =
       name === 'default'
-        ? 'No default secret key found. Set SUPABASE_SECRET_KEY or include a "default" entry in SUPABASE_SECRET_KEYS.'
-        : `No "${name}" secret key found. Include a "${name}" entry in SUPABASE_SECRET_KEYS.`
-    throw new EnvError(msg, MissingSecretKeyError)
+        ? new EnvError(
+            'No default secret key found. Set SUPABASE_SECRET_KEY or include a "default" entry in SUPABASE_SECRET_KEYS.',
+            MissingDefaultSecretKeyError,
+          )
+        : new EnvError(
+            `No "${name}" secret key found. Include a "${name}" entry in SUPABASE_SECRET_KEYS.`,
+            MissingSecretKeyError,
+          )
+
+    throw error
   }
 
   return createClient(resolved.url, secretKey, {

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -1,6 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-import { EnvError } from '../errors.js'
+import { EnvError, MissingSecretKeyError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
@@ -37,7 +37,7 @@ export function createAdminClient<Database = unknown>(
       name === 'default'
         ? 'No default secret key found. Set SUPABASE_SECRET_KEY or include a "default" entry in SUPABASE_SECRET_KEYS.'
         : `No "${name}" secret key found. Include a "${name}" entry in SUPABASE_SECRET_KEYS.`
-    throw new EnvError(msg, 'MISSING_SECRET_KEY')
+    throw new EnvError(msg, MissingSecretKeyError)
   }
 
   return createClient(resolved.url, secretKey, {

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -2,6 +2,7 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 import {
   EnvError,
+  Errors,
   MissingDefaultSecretKeyError,
   MissingSecretKeyError,
 } from '../errors.js'
@@ -37,18 +38,9 @@ export function createAdminClient<Database = unknown>(
   const secretKey =
     keys[name] ?? (keyName == null ? Object.values(keys)[0] : undefined)
   if (!secretKey) {
-    const error =
-      name === 'default'
-        ? new EnvError(
-            'No default secret key found. Set SUPABASE_SECRET_KEY or include a "default" entry in SUPABASE_SECRET_KEYS.',
-            MissingDefaultSecretKeyError,
-          )
-        : new EnvError(
-            `No "${name}" secret key found. Include a "${name}" entry in SUPABASE_SECRET_KEYS.`,
-            MissingSecretKeyError,
-          )
-
-    throw error
+    throw name === 'default'
+      ? Errors[MissingDefaultSecretKeyError]()
+      : Errors[MissingSecretKeyError](name)
   }
 
   return createClient(resolved.url, secretKey, {

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -1,7 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 import {
-  EnvError,
   Errors,
   MissingDefaultSecretKeyError,
   MissingSecretKeyError,

--- a/src/core/create-context-client.test.ts
+++ b/src/core/create-context-client.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { EnvError } from '../errors.js'
+import {
+  EnvError,
+  MissingDefaultPublishableKeyError,
+  MissingPublishableKeyError,
+} from '../errors.js'
 import { createContextClient } from './create-context-client.js'
 
 const validEnv = {
@@ -46,7 +50,7 @@ describe('createContextClient', () => {
       })
     } catch (e) {
       expect(e).toBeInstanceOf(EnvError)
-      expect((e as EnvError).code).toBe('MISSING_PUBLISHABLE_KEY')
+      expect((e as EnvError).code).toBe(MissingDefaultPublishableKeyError)
     }
   })
 
@@ -74,7 +78,7 @@ describe('createContextClient', () => {
       createContextClient('test-token', validEnv, 'nonexistent')
     } catch (e) {
       expect(e).toBeInstanceOf(EnvError)
-      expect((e as EnvError).code).toBe('MISSING_PUBLISHABLE_KEY')
+      expect((e as EnvError).code).toBe(MissingPublishableKeyError)
     }
   })
 

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -2,6 +2,7 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 import {
   EnvError,
+  Errors,
   MissingDefaultPublishableKeyError,
   MissingPublishableKeyError,
 } from '../errors.js'
@@ -41,18 +42,9 @@ export function createContextClient<Database = unknown>(
   const anonKey =
     keys[name] ?? (keyName == null ? Object.values(keys)[0] : undefined)
   if (!anonKey) {
-    const error =
-      name === 'default'
-        ? new EnvError(
-            'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.',
-            MissingDefaultPublishableKeyError,
-          )
-        : new EnvError(
-            `No "${name}" publishable key found. Include a "${name}" entry in SUPABASE_PUBLISHABLE_KEYS.`,
-            MissingPublishableKeyError,
-          )
-
-    throw error
+    throw name === 'default'
+      ? Errors[MissingDefaultPublishableKeyError]()
+      : Errors[MissingPublishableKeyError](name)
   }
 
   return createClient(resolved.url, anonKey, {

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -1,6 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-import { EnvError } from '../errors.js'
+import { EnvError, MissingPublishableKeyError } from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
@@ -41,7 +41,7 @@ export function createContextClient<Database = unknown>(
       name === 'default'
         ? 'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.'
         : `No "${name}" publishable key found. Include a "${name}" entry in SUPABASE_PUBLISHABLE_KEYS.`
-    throw new EnvError(msg, 'MISSING_PUBLISHABLE_KEY')
+    throw new EnvError(msg, MissingPublishableKeyError)
   }
 
   return createClient(resolved.url, anonKey, {

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -1,6 +1,10 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-import { EnvError, MissingPublishableKeyError } from '../errors.js'
+import {
+  EnvError,
+  MissingDefaultPublishableKeyError,
+  MissingPublishableKeyError,
+} from '../errors.js'
 import type { SupabaseEnv } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
@@ -37,11 +41,18 @@ export function createContextClient<Database = unknown>(
   const anonKey =
     keys[name] ?? (keyName == null ? Object.values(keys)[0] : undefined)
   if (!anonKey) {
-    const msg =
+    const error =
       name === 'default'
-        ? 'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.'
-        : `No "${name}" publishable key found. Include a "${name}" entry in SUPABASE_PUBLISHABLE_KEYS.`
-    throw new EnvError(msg, MissingPublishableKeyError)
+        ? new EnvError(
+            'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.',
+            MissingDefaultPublishableKeyError,
+          )
+        : new EnvError(
+            `No "${name}" publishable key found. Include a "${name}" entry in SUPABASE_PUBLISHABLE_KEYS.`,
+            MissingPublishableKeyError,
+          )
+
+    throw error
   }
 
   return createClient(resolved.url, anonKey, {

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -1,7 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 import {
-  EnvError,
   Errors,
   MissingDefaultPublishableKeyError,
   MissingPublishableKeyError,

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveEnv } from './resolve-env.js'
+import { MissingSupabaseURLError } from '../errors.js'
 
 describe('resolveEnv', () => {
   afterEach(() => {
@@ -10,7 +11,7 @@ describe('resolveEnv', () => {
   it('returns error when SUPABASE_URL is missing', () => {
     const result = resolveEnv()
     expect(result.error).not.toBeNull()
-    expect(result.error!.code).toBe('MISSING_SUPABASE_URL')
+    expect(result.error!.code).toBe(MissingSupabaseURLError)
   })
 
   it('reads SUPABASE_URL from process.env', () => {

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -1,4 +1,4 @@
-import { EnvError } from '../errors.js'
+import { EnvError, MissingSupabaseURLError } from '../errors.js'
 import type { JsonWebKeySet, SupabaseEnv } from '../types.js'
 
 /**
@@ -106,7 +106,7 @@ export function resolveEnv(
       data: null,
       error: new EnvError(
         'SUPABASE_URL is required but not set',
-        'MISSING_SUPABASE_URL',
+        MissingSupabaseURLError,
       ),
     }
   }

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -1,4 +1,4 @@
-import { EnvError, MissingSupabaseURLError } from '../errors.js'
+import { EnvError, Errors, MissingSupabaseURLError } from '../errors.js'
 import type { JsonWebKeySet, SupabaseEnv } from '../types.js'
 
 /**
@@ -104,10 +104,7 @@ export function resolveEnv(
   if (!url) {
     return {
       data: null,
-      error: new EnvError(
-        'SUPABASE_URL is required but not set',
-        MissingSupabaseURLError,
-      ),
+      error: Errors[MissingSupabaseURLError](),
     }
   }
 

--- a/src/core/verify-auth.ts
+++ b/src/core/verify-auth.ts
@@ -41,7 +41,7 @@ interface VerifyAuthOptions {
  * })
  *
  * if (error) {
- *   return Response.json({ error: error.message }, { status: error.status })
+ *   return Response.json({ message: error.message }, { status: error.status })
  * }
  *
  * console.log(auth.userClaims!.id) // "d0f1a2b3-..."

--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 
 import type { Credentials, JsonWebKeySet, SupabaseEnv } from '../types.js'
 import { verifyCredentials } from './verify-credentials.js'
+import { InvalidCredentialsError } from '../errors.js'
 
 function makeEnv(overrides?: Partial<SupabaseEnv>): Partial<SupabaseEnv> {
   return {
@@ -50,7 +51,7 @@ describe('verifyCredentials', () => {
         env: makeEnv(),
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('only matches default key when bare public is used', async () => {
@@ -66,7 +67,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('matches named key with colon syntax and returns keyName', async () => {
@@ -101,7 +102,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('rejects wrong named key type', async () => {
@@ -117,7 +118,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('matches any key with wildcard syntax', async () => {
@@ -179,7 +180,7 @@ describe('verifyCredentials', () => {
         env: makeEnv(),
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('only matches default key when bare secret is used', async () => {
@@ -192,7 +193,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('matches secret named key with colon syntax and returns keyName', async () => {
@@ -218,7 +219,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('rejects wrong secret named key type', async () => {
@@ -231,7 +232,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('matches any key with wildcard syntax', async () => {
@@ -309,7 +310,7 @@ describe('verifyCredentials', () => {
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('fails with no token', async () => {
@@ -319,7 +320,7 @@ describe('verifyCredentials', () => {
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
 
     it('fails with expired JWT', async () => {
@@ -341,7 +342,7 @@ describe('verifyCredentials', () => {
         env: makeEnv({ jwks: expiredJwks }),
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
   })
 
@@ -386,7 +387,7 @@ describe('verifyCredentials', () => {
         env,
       })
       expect(result.error).not.toBeNull()
-      expect(result.error!.code).toBe('INVALID_CREDENTIALS')
+      expect(result.error!.code).toBe(InvalidCredentialsError)
     })
   })
 

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -203,7 +203,7 @@ async function tryMode(
  *   allow: ['user', 'public'],
  * })
  * if (error) {
- *   return Response.json({ error: error.message }, { status: error.status })
+ *   return Response.json({ message: error.message }, { status: error.status })
  * }
  * ```
  */

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -1,6 +1,6 @@
 import { createLocalJWKSet, jwtVerify } from 'jose'
 
-import { AuthError, InvalidCredentialsError } from '../errors.js'
+import { AuthError, Errors, InvalidCredentialsError } from '../errors.js'
 import type {
   Allow,
   AllowWithKey,
@@ -232,6 +232,6 @@ export async function verifyCredentials(
 
   return {
     data: null,
-    error: new AuthError('Invalid credentials', InvalidCredentialsError, 401),
+    error: Errors[InvalidCredentialsError](),
   }
 }

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -1,6 +1,6 @@
 import { createLocalJWKSet, jwtVerify } from 'jose'
 
-import { AuthError } from '../errors.js'
+import { AuthError, InvalidCredentialsError } from '../errors.js'
 import type {
   Allow,
   AllowWithKey,
@@ -232,6 +232,6 @@ export async function verifyCredentials(
 
   return {
     data: null,
-    error: new AuthError('Invalid credentials', 'INVALID_CREDENTIALS', 401),
+    error: new AuthError('Invalid credentials', InvalidCredentialsError, 401),
   }
 }

--- a/src/create-supabase-context.test.ts
+++ b/src/create-supabase-context.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { createSupabaseContext } from './create-supabase-context.js'
+import {
+  MissingDefaultPublishableKeyError,
+  MissingDefaultSecretKeyError,
+} from './errors.js'
 
 const baseEnv = {
   url: 'https://test.supabase.co',
@@ -113,6 +117,9 @@ describe('createSupabaseContext', () => {
     expect(result.data).toBeNull()
     expect(result.error).not.toBeNull()
     expect(result.error!.status).toBe(500)
-    expect(result.error!.code).toBe('MISSING_PUBLISHABLE_KEY')
+    expect(result.error!.code).toBeOneOf([
+      MissingDefaultPublishableKeyError,
+      MissingDefaultSecretKeyError,
+    ])
   })
 })

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -1,4 +1,9 @@
-import { AuthError, ClientError, EnvError } from './errors.js'
+import {
+  AuthError,
+  CreateSupabaseClientError,
+  EnvError,
+  Errors,
+} from './errors.js'
 import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 import { createAdminClient } from './core/create-admin-client.js'
 import { createContextClient } from './core/create-context-client.js'
@@ -67,7 +72,7 @@ export async function createSupabaseContext<Database = unknown>(
     const error =
       e instanceof EnvError
         ? new AuthError(e.message, e.code, 500)
-        : new AuthError('Failed to create Supabase client', ClientError, 500)
+        : Errors[CreateSupabaseClientError]()
     return { data: null, error }
   }
 }

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -19,7 +19,7 @@ import { verifyAuth } from './core/verify-auth.js'
  * ```ts
  * const { data: ctx, error } = await createSupabaseContext(request, { allow: 'user' })
  * if (error) {
- *   return Response.json({ error: error.message }, { status: error.status })
+ *   return Response.json({ message: error.message }, { status: error.status })
  * }
  * const { data } = await ctx.supabase.rpc('get_my_items')
  * ```

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -1,4 +1,4 @@
-import { AuthError, EnvError } from './errors.js'
+import { AuthError, ClientError, EnvError } from './errors.js'
 import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 import { createAdminClient } from './core/create-admin-client.js'
 import { createContextClient } from './core/create-context-client.js'
@@ -67,7 +67,7 @@ export async function createSupabaseContext<Database = unknown>(
     const error =
       e instanceof EnvError
         ? new AuthError(e.message, e.code, 500)
-        : new AuthError('Failed to create Supabase client', 'CLIENT_ERROR', 500)
+        : new AuthError('Failed to create Supabase client', ClientError, 500)
     return { data: null, error }
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,8 +27,10 @@ export class EnvError extends Error {
    *
    * Known codes:
    * - `"MISSING_SUPABASE_URL"` — `SUPABASE_URL` not set
-   * - `"MISSING_PUBLISHABLE_KEY"` — No publishable key found
-   * - `"MISSING_SECRET_KEY"` — No secret key found
+   * - `"MISSING_PUBLISHABLE_KEY"` — No publishable key found for the given keyname
+   * - `"MISSING_DEFATUL_PUBLISHABLE_KEY"` — No default publishable key found
+   * - `"MISSING_SECRET_KEY"` — No secret key found for the given keyname
+   * - `"MISSING_DEFAULT_SECRET_KEY"` — No defatult secret key found
    * - `"ENV_ERROR"` — Generic environment error
    */
   readonly code: string

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,7 @@
 /**
  * Thrown when a required environment variable is missing or malformed.
  *
- * Has a fixed `status` of `500` since environment errors are server-side
- * configuration issues, not client errors.
+ * Always has `status: 500` — environment errors are server-side configuration issues.
  *
  * @example
  * ```ts
@@ -25,13 +24,9 @@ export class EnvError extends Error {
   /**
    * Machine-readable error code.
    *
-   * Known codes:
-   * - `"MISSING_SUPABASE_URL"` — `SUPABASE_URL` not set
-   * - `"MISSING_PUBLISHABLE_KEY"` — No publishable key found for the given keyname
-   * - `"MISSING_DEFATUL_PUBLISHABLE_KEY"` — No default publishable key found
-   * - `"MISSING_SECRET_KEY"` — No secret key found for the given keyname
-   * - `"MISSING_DEFAULT_SECRET_KEY"` — No defatult secret key found
-   * - `"ENV_ERROR"` — Generic environment error
+   * @see {@link EnvGenericError}, {@link MissingSupabaseURLError},
+   *   {@link MissingPublishableKeyError}, {@link MissingDefaultPublishableKeyError},
+   *   {@link MissingSecretKeyError}, {@link MissingDefaultSecretKeyError}
    */
   readonly code: string
 
@@ -42,12 +37,23 @@ export class EnvError extends Error {
   }
 }
 
+/** Generic environment error code. */
 export const EnvGenericError = 'ENV_ERROR'
+
+/** `SUPABASE_URL` is not set. */
 export const MissingSupabaseURLError = 'MISSING_SUPABASE_URL'
+
+/** Named publishable key not found in `SUPABASE_PUBLISHABLE_KEYS`. */
 export const MissingPublishableKeyError = 'MISSING_PUBLISHABLE_KEY'
+
+/** No default publishable key found. */
 export const MissingDefaultPublishableKeyError =
   'MISSING_DEFAULT_PUBLISHABLE_KEY'
+
+/** Named secret key not found in `SUPABASE_SECRET_KEYS`. */
 export const MissingSecretKeyError = 'MISSING_SECRET_KEY'
+
+/** No default secret key found. */
 export const MissingDefaultSecretKeyError = 'MISSING_DEFAULT_SECRET_KEY'
 
 const EnvErrorMap = {
@@ -111,11 +117,8 @@ export class AuthError extends Error {
   /**
    * Machine-readable error code.
    *
-   * Known codes:
-   * - `"INVALID_CREDENTIALS"` — No credential matched any allowed auth mode
-   * - `"CLIENT_ERROR"` — Failed to create a Supabase client after auth succeeded
-   * - `"AUTH_ERROR"` — Generic authentication error
-   * - Any `EnvError` code (propagated when env resolution fails during auth)
+   * @see {@link AuthGenericError}, {@link InvalidCredentialsError},
+   *   {@link CreateSupabaseClientError}
    */
   readonly code: string
 
@@ -127,8 +130,13 @@ export class AuthError extends Error {
   }
 }
 
+/** Generic authentication error code. */
 export const AuthGenericError = 'AUTH_ERROR'
+
+/** No credential matched any allowed auth mode. */
 export const InvalidCredentialsError = 'INVALID_CREDENTIALS'
+
+/** Failed to create a Supabase client after auth succeeded. */
 export const CreateSupabaseClientError = 'CREATE_SUPABASE_CLIENT_ERROR'
 
 const AuthErrorMap = {
@@ -142,6 +150,16 @@ const AuthErrorMap = {
     ),
 }
 
+/**
+ * Factory map for all error types. Keyed by error code constant, each entry
+ * returns a pre-configured {@link EnvError} or {@link AuthError}.
+ *
+ * @example
+ * ```ts
+ * throw Errors[MissingSupabaseURLError]()
+ * throw Errors[MissingPublishableKeyError]('mobile')
+ * ```
+ */
 export const Errors = {
   ...EnvErrorMap,
   ...AuthErrorMap,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -73,7 +73,7 @@ const EnvErrorMap = {
   [MissingDefaultPublishableKeyError]: () =>
     new EnvError(
       'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.',
-      MissingDefaultSecretKeyError,
+      MissingDefaultPublishableKeyError,
     ),
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -40,13 +40,42 @@ export class EnvError extends Error {
   }
 }
 
+export const EnvGenericError = 'ENV_ERROR'
 export const MissingSupabaseURLError = 'MISSING_SUPABASE_URL'
 export const MissingPublishableKeyError = 'MISSING_PUBLISHABLE_KEY'
 export const MissingDefaultPublishableKeyError =
   'MISSING_DEFAULT_PUBLISHABLE_KEY'
 export const MissingSecretKeyError = 'MISSING_SECRET_KEY'
 export const MissingDefaultSecretKeyError = 'MISSING_DEFAULT_SECRET_KEY'
-export const EnvGenericError = 'ENV_ERROR'
+
+const EnvErrorMap = {
+  [MissingSupabaseURLError]: () =>
+    new EnvError(
+      'SUPABASE_URL is required but not set',
+      MissingSupabaseURLError,
+    ),
+  [MissingSecretKeyError]: (name: string) =>
+    new EnvError(
+      `No "${name}" secret key found. Include a "${name}" entry in SUPABASE_SECRET_KEYS.`,
+      MissingSecretKeyError,
+    ),
+  [MissingDefaultSecretKeyError]: () =>
+    new EnvError(
+      'No default secret key found. Set SUPABASE_SECRET_KEY or include a "default" entry in SUPABASE_SECRET_KEYS.',
+      MissingDefaultSecretKeyError,
+    ),
+
+  [MissingPublishableKeyError]: (name: string) =>
+    new EnvError(
+      `No "${name}" publishable key found. Include a "${name}" entry in SUPABASE_PUBLISHABLE_KEYS.`,
+      MissingPublishableKeyError,
+    ),
+  [MissingDefaultPublishableKeyError]: () =>
+    new EnvError(
+      'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.',
+      MissingDefaultSecretKeyError,
+    ),
+}
 
 /**
  * Thrown when authentication or authorization fails.
@@ -96,6 +125,22 @@ export class AuthError extends Error {
   }
 }
 
-export const InvalidCredentialsError = 'INVALID_CREDENTIALS'
-export const ClientError = 'CLIENT_ERROR'
 export const AuthGenericError = 'AUTH_ERROR'
+export const InvalidCredentialsError = 'INVALID_CREDENTIALS'
+export const CreateSupabaseClientError = 'CREATE_SUPABASE_CLIENT_ERROR'
+
+const AuthErrorMap = {
+  [InvalidCredentialsError]: () =>
+    new AuthError('Invalid credentials', InvalidCredentialsError, 401),
+  [CreateSupabaseClientError]: () =>
+    new AuthError(
+      'Failed to create Supabase client',
+      CreateSupabaseClientError,
+      500,
+    ),
+}
+
+export const Errors = {
+  ...EnvErrorMap,
+  ...AuthErrorMap,
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -54,7 +54,7 @@ export class EnvError extends Error {
  * if (error) {
  *   // error is an AuthError
  *   return Response.json(
- *     { error: error.message, code: error.code },
+ *     { message: error.message, code: error.code },
  *     { status: error.status },
  *   )
  * }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -33,12 +33,17 @@ export class EnvError extends Error {
    */
   readonly code: string
 
-  constructor(message: string, code = 'ENV_ERROR') {
+  constructor(message: string, code = EnvGenericError) {
     super(message)
     this.name = 'EnvError'
     this.code = code
   }
 }
+
+export const MissingSupabaseURLError = 'MISSING_SUPABASE_URL'
+export const MissingPublishableKeyError = 'MISSING_PUBLISHABLE_KEY'
+export const MissingSecretKeyError = 'MISSING_SECRET_KEY'
+export const EnvGenericError = 'ENV_ERROR'
 
 /**
  * Thrown when authentication or authorization fails.
@@ -80,10 +85,14 @@ export class AuthError extends Error {
    */
   readonly code: string
 
-  constructor(message: string, code = 'AUTH_ERROR', status = 401) {
+  constructor(message: string, code = AuthGenericError, status = 401) {
     super(message)
     this.name = 'AuthError'
     this.code = code
     this.status = status
   }
 }
+
+export const InvalidCredentialsError = 'INVALID_CREDENTIALS'
+export const ClientError = 'CLIENT_ERROR'
+export const AuthGenericError = 'AUTH_ERROR'

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,7 +42,10 @@ export class EnvError extends Error {
 
 export const MissingSupabaseURLError = 'MISSING_SUPABASE_URL'
 export const MissingPublishableKeyError = 'MISSING_PUBLISHABLE_KEY'
+export const MissingDefaultPublishableKeyError =
+  'MISSING_DEFAULT_PUBLISHABLE_KEY'
 export const MissingSecretKeyError = 'MISSING_SECRET_KEY'
+export const MissingDefaultSecretKeyError = 'MISSING_DEFAULT_SECRET_KEY'
 export const EnvGenericError = 'ENV_ERROR'
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,18 @@ export type {
   UserClaims,
   WithSupabaseConfig,
 } from './types.js'
-export { AuthError, EnvError } from './errors.js'
+
+export {
+  AuthError,
+  AuthGenericError,
+  CreateSupabaseClientError,
+  EnvError,
+  EnvGenericError,
+  Errors,
+  InvalidCredentialsError,
+  MissingDefaultPublishableKeyError,
+  MissingDefaultSecretKeyError,
+  MissingPublishableKeyError,
+  MissingSecretKeyError,
+  MissingSupabaseURLError,
+} from './errors.js'

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -62,7 +62,7 @@ describe('withSupabase', () => {
     const res = await handler(req)
     expect(res.status).toBe(401)
     const body = await res.json()
-    expect(body.error).toBeDefined()
+    expect(body.message).toBeDefined()
     expect(body.code).toBeDefined()
   })
 

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -43,7 +43,7 @@ export function withSupabase<Database = unknown>(
     )
     if (error) {
       return Response.json(
-        { error: error.message, code: error.code },
+        { message: error.message, code: error.code },
         {
           status: error.status,
           headers: config.cors !== false ? buildCorsHeaders(config.cors) : {},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Errors differ from ingress api

## What is the new behavior?

- Standardize errors to match same response object as ingress
- Creating error maps to avoid magic strings

### Addiontal Context

<details>

https://github.com/user-attachments/assets/03aeac7f-663c-4944-b60f-000e8b9a0de2

</details>