### PR TITLE
feat: exposing `keyName` to `SupabaseContext`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,7 @@ Every handler receives a `SupabaseContext` with these fields:
 | `userClaims`    | `UserClaims \| null` | JWT-derived identity (`id`, `email`, `role`, `appMetadata`, `userMetadata`). `null` for non-user auth. |
 | `claims`        | `JWTClaims \| null`  | Raw JWT payload (snake_case). `null` for non-user auth.                                                |
 | `authType`      | `Allow`              | Which auth mode matched: `'user'`, `'public'`, `'secret'`, or `'always'`.                              |
+| `authKeyName`   | `string \| null`     | Which auth key name of the API key that was used.                                                      |
 
 The `supabase` client respects Row-Level Security. When `authType` is `'user'`, the client is scoped to that user's permissions. For other auth modes, it's initialized as anonymous.
 

--- a/src/create-supabase-context.test.ts
+++ b/src/create-supabase-context.test.ts
@@ -26,6 +26,7 @@ describe('createSupabaseContext', () => {
     expect(result.data!.supabase).toBeDefined()
     expect(result.data!.supabaseAdmin).toBeDefined()
     expect(result.data!.authType).toBe('always')
+    expect(result.data!.authKeyName).toBeNull()
   })
 
   it('returns user and claims as null for non-user auth', async () => {
@@ -72,6 +73,28 @@ describe('createSupabaseContext', () => {
 
     expect(result.error).toBeNull()
     expect(result.data!.authType).toBe('public')
+    expect(result.data!.authKeyName).toBe('default')
+    expect(result.data!.supabase).toBeDefined()
+    expect(result.data!.supabaseAdmin).toBeDefined()
+  })
+
+  it('accepts public named key auth', async () => {
+    const req = new Request('http://localhost', {
+      headers: { apikey: 'sb_publishable_web' },
+    })
+    const result = await createSupabaseContext(req, {
+      allow: 'public:web',
+      env: {
+        ...baseEnv,
+        publishableKeys: {
+          web: 'sb_publishable_web',
+        },
+      },
+    })
+
+    expect(result.error).toBeNull()
+    expect(result.data!.authType).toBe('public')
+    expect(result.data!.authKeyName).toBe('web')
     expect(result.data!.supabase).toBeDefined()
     expect(result.data!.supabaseAdmin).toBeDefined()
   })
@@ -87,6 +110,28 @@ describe('createSupabaseContext', () => {
 
     expect(result.error).toBeNull()
     expect(result.data!.authType).toBe('secret')
+    expect(result.data!.authKeyName).toBe('default')
+  })
+
+  it('accepts secret named key auth', async () => {
+    const req = new Request('http://localhost', {
+      headers: { apikey: 'sb_secret_web' },
+    })
+    const result = await createSupabaseContext(req, {
+      allow: 'secret:web',
+      env: {
+        ...baseEnv,
+        secretKeys: {
+          web: 'sb_secret_web',
+        },
+      },
+    })
+
+    expect(result.error).toBeNull()
+    expect(result.data!.authType).toBe('secret')
+    expect(result.data!.authKeyName).toBe('web')
+    expect(result.data!.supabase).toBeDefined()
+    expect(result.data!.supabaseAdmin).toBeDefined()
   })
 
   it('rejects invalid secret key', async () => {

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -52,8 +52,9 @@ export async function createSupabaseContext<Database = unknown>(
       supabaseOptions: options?.supabaseOptions,
     }
 
+    const publicKeyName = auth.authType === 'public' ? auth.keyName : undefined
     const supabase = createContextClient<Database>({
-      auth: { token: auth.token, keyName: auth.keyName },
+      auth: { token: auth.token, keyName: publicKeyName },
       ...config,
     })
 
@@ -70,6 +71,7 @@ export async function createSupabaseContext<Database = unknown>(
         userClaims: auth.userClaims,
         claims: auth.claims,
         authType: auth.authType,
+        authKeyName: auth.keyName,
       },
       error: null,
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,4 +313,7 @@ export interface SupabaseContext<Database = unknown> {
 
   /** The auth mode that was used for this request. */
   authType: Allow
+
+  /** The auth key name of the API key that was used for this request. */
+  authKeyName?: string | null
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update

## What is the current behavior?

- `SupabaseContext` doesn't have the `auth.keyName` which would be useful for some cases.
- Also, while specifying `secret:key` there's a bug which requires this key to be defined at `publishableKeys` environment prop.

## What is the new behavior?

- Exposing `authKeyName` property to `SupabaseContext`
- Apply `authType` verification before passing down the `keyName` while creating the supabase client 