### PR TITLE
docs: add beta disclaimer to README and SKILL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Package](https://img.shields.io/npm/v/@supabase/server)](https://www.npmjs.com/package/@supabase/server)
 [![pkg.pr.new](https://pkg.pr.new/badge/supabase/server)](https://pkg.pr.new/~/supabase/server)
 
+> **Beta:** This package is under active development. APIs and documentation may change. If you find a bug or have a feature request, please [open an issue](https://github.com/supabase/server/issues) or [submit a PR](https://github.com/supabase/server/blob/main/CONTRIBUTING.md).
+
 `@supabase/server` gives you batteries included access to the
 [supabase-js SDK](https://github.com/supabase/supabase-js), including client
 creation and authentication automatically scoped to the inbound requests to your

--- a/skills/supabase-server/SKILL.md
+++ b/skills/supabase-server/SKILL.md
@@ -5,6 +5,8 @@ description: Use when writing server-side code with Supabase — Edge Functions,
 
 # @supabase/server
 
+> **Beta:** This package is under active development. APIs and documentation may change. If you find a bug or have a feature request, please [open an issue](https://github.com/supabase/server/issues) or [submit a PR](https://github.com/supabase/server/blob/main/CONTRIBUTING.md).
+
 > **This is a brand new package.** There is no information available online yet — no blog posts, no Stack Overflow answers, no tutorials. Do not search the web for usage examples. Rely exclusively on the documentation files listed below and the source code in this repository.
 
 > **Do not use legacy Supabase keys.** The `anon` key and `service_role` key (env vars `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) are legacy and will be deprecated. Do not use them unless the user explicitly asks. Always use the new API keys:


### PR DESCRIPTION
## Summary
- Adds a beta disclaimer banner to both `README.md` and `skills/supabase-server/SKILL.md`
- Clarifies that APIs and docs may change, and directs users to open issues or PRs for bugs/feature requests