### PR TITLE
docs: document userClaims and authKeyName in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ interface SupabaseContext {
   userClaims: UserClaims | null // JWT-derived identity (for full User, call supabase.auth.getUser())
   claims: JWTClaims | null // Present when auth is JWT
   authType: Allow // Which auth mode matched
+  authKeyName?: string | null // Auth key name of the API key that was used for this request
 }
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,7 +56,7 @@ JWT verification in `user` mode works as follows:
 2. The token is verified against the JWKS from the `SUPABASE_JWKS` environment variable
 3. Verification uses `jose`'s `jwtVerify` with a **local** key set — there are no network calls to a JWKS endpoint
 4. The token must contain a `sub` (subject) claim to be considered valid
-5. On success, the decoded claims are available as `ctx.user` and `ctx.claims`
+5. On success, the decoded claims are available as `ctx.userClaims` and `ctx.claims`
 
 If JWKS is not configured (`SUPABASE_JWKS` is missing or malformed), `user` mode is unavailable and will always reject requests.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

docs referenced `ctx.user` instead of defined `ctx.userClaims` for JWT-derived claims in user auth mode

## What is the new behavior?

updated docs to correctly reference `ctx.userClaims` and optional `authKeyName`
