### PR TITLE
fix: reject invalid JWTs instead of silent fallthrough to next auth mode

### DIFF
--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -416,4 +416,71 @@ describe('verifyCredentials', () => {
       expect(result.data!.authType).toBe('always')
     })
   })
+
+  describe('invalid credential rejection (no silent fallthrough)', () => {
+    let jwks: JsonWebKeySet
+
+    beforeAll(async () => {
+      const { publicKey } = await generateKeyPair('RS256')
+      const publicJwk = await exportJWK(publicKey)
+      publicJwk.alg = 'RS256'
+      publicJwk.use = 'sig'
+      jwks = { keys: [publicJwk] }
+    })
+
+    it('rejects invalid JWT instead of falling through to always mode', async () => {
+      const creds: Credentials = { token: 'garbage.jwt.token', apikey: null }
+      const result = await verifyCredentials(creds, {
+        allow: ['user', 'always'],
+        env: makeEnv({ jwks }),
+      })
+      expect(result.error).not.toBeNull()
+      expect(result.error!.code).toBe(InvalidCredentialsError)
+    })
+
+    it('rejects expired JWT instead of falling through to always mode', async () => {
+      const { privateKey, publicKey } = await generateKeyPair('RS256')
+      const publicJwk = await exportJWK(publicKey)
+      publicJwk.alg = 'RS256'
+      publicJwk.use = 'sig'
+      const expiredJwks = { keys: [publicJwk] }
+
+      const expiredToken = await new SignJWT({ sub: 'user-123' })
+        .setProtectedHeader({ alg: 'RS256' })
+        .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+        .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+        .sign(privateKey)
+
+      const creds: Credentials = { token: expiredToken, apikey: null }
+      const result = await verifyCredentials(creds, {
+        allow: ['user', 'always'],
+        env: makeEnv({ jwks: expiredJwks }),
+      })
+      expect(result.error).not.toBeNull()
+      expect(result.error!.code).toBe(InvalidCredentialsError)
+    })
+
+    it('falls through to always when no token is present', async () => {
+      const creds: Credentials = { token: null, apikey: null }
+      const result = await verifyCredentials(creds, {
+        allow: ['user', 'always'],
+        env: makeEnv({ jwks }),
+      })
+      expect(result.error).toBeNull()
+      expect(result.data!.authType).toBe('always')
+    })
+
+    it('rejects invalid JWT even when public mode follows', async () => {
+      const creds: Credentials = {
+        token: 'garbage.jwt.token',
+        apikey: 'sb_publishable_xyz',
+      }
+      const result = await verifyCredentials(creds, {
+        allow: ['user', 'public'],
+        env: makeEnv({ jwks }),
+      })
+      expect(result.error).not.toBeNull()
+      expect(result.error!.code).toBe(InvalidCredentialsError)
+    })
+  })
 })

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -73,16 +73,23 @@ function claimsToUserClaims(claims: JWTClaims): UserClaims {
   }
 }
 
+const INVALID = Symbol('invalid')
+
 /**
  * Attempts to authenticate credentials against a single auth mode.
- * Returns the {@link AuthResult} on success, or `null` if the mode doesn't match.
+ *
+ * Returns:
+ * - `AuthResult` on success.
+ * - `null` if the mode doesn't apply (no relevant credential present — safe to try the next mode).
+ * - `INVALID` if a credential was present but failed verification (must reject immediately).
+ *
  * @internal
  */
 async function tryMode(
   mode: AllowWithKey,
   credentials: Credentials,
   env: SupabaseEnv,
-): Promise<AuthResult | null> {
+): Promise<AuthResult | typeof INVALID | null> {
   const { base, keyName } = parseAllowMode(mode)
 
   switch (base) {
@@ -166,7 +173,7 @@ async function tryMode(
         const jwkSet = createLocalJWKSet(env.jwks)
         const { payload } = await jwtVerify(credentials.token, jwkSet)
         if (typeof payload.sub !== 'string') {
-          return null
+          return INVALID
         }
         const claims = payload as unknown as JWTClaims
         return {
@@ -177,7 +184,7 @@ async function tryMode(
           keyName: null,
         }
       } catch {
-        return null
+        return INVALID
       }
     }
 
@@ -225,6 +232,9 @@ export async function verifyCredentials(
 
   for (const mode of modes) {
     const result = await tryMode(mode, credentials, env)
+    if (result === INVALID) {
+      return { data: null, error: Errors[InvalidCredentialsError]() }
+    }
     if (result) {
       return { data: result, error: null }
     }


### PR DESCRIPTION
## Summary

- When `allow` is an array (e.g. `['user', 'always']`), an invalid JWT (malformed, expired, wrong key) was silently falling through to the next auth mode via `catch { return null }` in `tryMode`. A garbage JWT like `"this.is.garbage"` would succeed with `authType: 'always'` instead of returning a 401.
- This PR introduces a three-value return from `tryMode`: `AuthResult` (success), `null` (no relevant credential — safe to try next mode), `INVALID` (credential present but failed — reject immediately).
- `public`/`secret` modes are **not** changed to use `INVALID` on key mismatch, because the `apikey` header is shared between both modes — a key that doesn't match `secret` should still be allowed to try `public`.

## Test plan

- [x] New test: invalid JWT with `['user', 'always']` → rejected (was accepted before)
- [x] New test: expired JWT with `['user', 'always']` → rejected (was accepted before)
- [x] New test: no token with `['user', 'always']` → falls through to `always` (correct behavior preserved)
- [x] New test: invalid JWT with `['user', 'public']` + valid apikey → rejected (JWT failure takes precedence)
- [x] All 108 existing tests still pass
- [x] Build and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)