### PR TITLE
ci: setup jsr publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
       - run: pnpm typecheck
 
       - run: pnpm lint
+
+      - name: Verify JSR packaging
+        run: pnpm dlx jsr publish --dry-run --allow-dirty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,11 @@ jobs:
           # TODO(@mandarini): add back --provenance once repo is OSS
           npm publish --access public --tag "${{ steps.version.outputs.tag }}"
 
+      - name: Publish to JSR
+        if: ${{ steps.version.outputs.skip != 'true' }}
+        continue-on-error: true
+        run: npx jsr publish --allow-dirty
+
       - name: Create GitHub pre-release
         if: ${{ steps.version.outputs.tag == 'rc' }}
         env:

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,13 @@
+{
+  "name": "@supabase/server",
+  "version": "0.1.4",
+  "exports": {
+    ".": "./src/index.ts",
+    "./core": "./src/core/index.ts",
+    "./adapters/hono": "./src/adapters/hono/index.ts"
+  },
+  "publish": {
+    "include": ["src/**/*.ts", "README.md", "LICENSE"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "node",
       "initial-version": "0.1.0",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": ["jsr.json"]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -1,3 +1,4 @@
+import type { MiddlewareHandler } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { createMiddleware } from 'hono/factory'
 
@@ -30,7 +31,9 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * export default { fetch: app.fetch }
  * ```
  */
-export function withSupabase(config?: Omit<WithSupabaseConfig, 'cors'>) {
+export function withSupabase(
+  config?: Omit<WithSupabaseConfig, 'cors'>,
+): MiddlewareHandler<{ Variables: { supabaseContext: SupabaseContext } }> {
   return createMiddleware<{
     Variables: { supabaseContext: SupabaseContext }
   }>(async (c, next) => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -57,28 +57,28 @@ export const MissingSecretKeyError = 'MISSING_SECRET_KEY'
 export const MissingDefaultSecretKeyError = 'MISSING_DEFAULT_SECRET_KEY'
 
 const EnvErrorMap = {
-  [MissingSupabaseURLError]: () =>
+  [MissingSupabaseURLError]: (): EnvError =>
     new EnvError(
       'SUPABASE_URL is required but not set',
       MissingSupabaseURLError,
     ),
-  [MissingSecretKeyError]: (name: string) =>
+  [MissingSecretKeyError]: (name: string): EnvError =>
     new EnvError(
       `No "${name}" secret key found. Include a "${name}" entry in SUPABASE_SECRET_KEYS.`,
       MissingSecretKeyError,
     ),
-  [MissingDefaultSecretKeyError]: () =>
+  [MissingDefaultSecretKeyError]: (): EnvError =>
     new EnvError(
       'No default secret key found. Set SUPABASE_SECRET_KEY or include a "default" entry in SUPABASE_SECRET_KEYS.',
       MissingDefaultSecretKeyError,
     ),
 
-  [MissingPublishableKeyError]: (name: string) =>
+  [MissingPublishableKeyError]: (name: string): EnvError =>
     new EnvError(
       `No "${name}" publishable key found. Include a "${name}" entry in SUPABASE_PUBLISHABLE_KEYS.`,
       MissingPublishableKeyError,
     ),
-  [MissingDefaultPublishableKeyError]: () =>
+  [MissingDefaultPublishableKeyError]: (): EnvError =>
     new EnvError(
       'No default publishable key found. Set SUPABASE_PUBLISHABLE_KEY or include a "default" entry in SUPABASE_PUBLISHABLE_KEYS.',
       MissingDefaultPublishableKeyError,
@@ -140,9 +140,9 @@ export const InvalidCredentialsError = 'INVALID_CREDENTIALS'
 export const CreateSupabaseClientError = 'CREATE_SUPABASE_CLIENT_ERROR'
 
 const AuthErrorMap = {
-  [InvalidCredentialsError]: () =>
+  [InvalidCredentialsError]: (): AuthError =>
     new AuthError('Invalid credentials', InvalidCredentialsError, 401),
-  [CreateSupabaseClientError]: () =>
+  [CreateSupabaseClientError]: (): AuthError =>
     new AuthError(
       'Failed to create Supabase client',
       CreateSupabaseClientError,


### PR DESCRIPTION
## Summary

Adds JSR (jsr.io) publishing so `@supabase/server` can be consumed natively by Deno users via `jsr:@supabase/server`.

## What changed

- **`jsr.json`** -- new package config with all three export entry points (`.`, `./core`, `./adapters/hono`) pointing to TypeScript source files
- **`release-please-config.json`** -- added `jsr.json` to `extra-files` so release-please bumps the version in both `package.json` and `jsr.json` atomically
- **`release.yml`** -- added a "Publish to JSR" step after npm publish, using OIDC auth (`id-token: write` was already configured). Runs with `continue-on-error: true` so JSR failures never block the npm release
- **`ci.yml`** -- added a `jsr publish --dry-run` step to catch packaging errors (slow types, bad exports) on every push/PR
- **`src/errors.ts`** -- added explicit return type annotations to all arrow functions in `EnvErrorMap` and `AuthErrorMap` (required by JSR's "no slow types" rule since the `Errors` object is publicly exported)
- **`src/adapters/hono/middleware.ts`** -- added explicit `MiddlewareHandler` return type to the exported `withSupabase` function (same reason)

## Design decisions

- **Version managed by release-please**, not a CI-stamped placeholder. The `extra-files` config uses release-please's built-in `GenericJson` updater for `.json` files.
- **No separate publish script** -- the workflow step is a single `npx jsr publish --allow-dirty` since all version management is handled by release-please.
- **JSR publishes from source** (`.ts` files), not from `dist/`. The `publish.include` field scopes what gets uploaded.
- **Non-blocking** -- mirrors the pattern used in `supabase-js` where JSR is secondary to npm.
