### PR TITLE
docs: fix incorrect middleware execution order in Hono adapter

### DIFF
--- a/docs/hono-adapter.md
+++ b/docs/hono-adapter.md
@@ -81,22 +81,11 @@ export default { fetch: app.fetch }
 
 ## Skip behavior
 
-If a previous middleware already set `c.var.supabaseContext`, subsequent `withSupabase` calls skip auth. This enables a pattern where route-level middleware overrides the app-wide default:
+If a previous middleware already set `c.var.supabaseContext`, subsequent `withSupabase` calls skip auth. This matters when multiple `app.use` middlewares overlap on the same path — the first one to set the context wins.
 
-```ts
-const app = new Hono()
+**Important:** Hono runs middleware in registration order (`app.use` before route-level middleware). An `app.use('*', ...)` middleware will always run before inline route middleware, so the skip-if-set pattern cannot be used to make a route stricter than the app-wide default.
 
-// App-wide: require user auth
-app.use('*', withSupabase({ allow: 'user' }))
-
-// This route needs secret auth instead.
-// The route-level middleware runs first, sets the context,
-// and the app-wide middleware skips.
-app.post('/webhook', withSupabase({ allow: 'secret' }), async (c) => {
-  const { supabaseAdmin } = c.var.supabaseContext
-  // ...
-})
-```
+For routes that need different auth than the rest of the app, use per-route middleware without an app-wide middleware (see the "Per-route auth" section above).
 
 ## CORS
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

The "Skip behavior" section in `docs/hono-adapter.md` says:

> The route-level middleware runs first, sets the context, and the app-wide middleware skips.

This is wrong. Hono runs middleware in registration order. `app.use('*', ...)` registered before `app.post('/path', middleware, handler)` means the app-wide middleware always runs first. From Hono's docs:

> The order in which Middleware is executed is determined by the order in which it is registered.

https://hono.dev/docs/guides/middleware#execution-order

So the documented pattern:

```ts
app.use('*', withSupabase({ allow: 'user' }))
app.post('/webhook', withSupabase({ allow: 'secret' }), handler)
```

does the opposite of what the comment says. The app-wide `'user'` middleware runs first. If a JWT is valid, it sets context and the route-level `'secret'` never checks. If only a secret key is sent (no JWT), the app-wide middleware rejects before the route-level middleware runs.

## What is the new behavior?

Replaced the section with a note about the actual execution order. The skip-if-set pattern only applies when two `app.use` middlewares overlap on the same path (first registered wins). For routes that need different auth, the existing "Per-route auth" pattern (inline middleware, no app-wide middleware) is the right approach and is already documented in the section above.