### PR TITLE
feat: rename `allow` config option to `auth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,29 @@
 
 ## [0.1.4](https://github.com/supabase/server/compare/server-v0.1.3...server-v0.1.4) (2026-04-01)
 
-
 ### Features
 
-* add `supabaseOptions` and refactor client creation to options objects ([#19](https://github.com/supabase/server/issues/19)) ([5a10099](https://github.com/supabase/server/commit/5a100995a1b6254f92768c82c74b1c754c29b3b2))
-* exposing `keyName` to `SupabaseContext` ([#22](https://github.com/supabase/server/issues/22)) ([7f1b1a7](https://github.com/supabase/server/commit/7f1b1a75cc98d08a63275131481e5df825c10afb))
-* implement server-side DX primitives, wrappers, and adapters ([#6](https://github.com/supabase/server/issues/6)) ([d206e5c](https://github.com/supabase/server/commit/d206e5cdb102bf96e0c501b72e7f161cbf9fba0c))
-* passing down Database generic type to `createClient` ([#16](https://github.com/supabase/server/issues/16)) ([4053f6d](https://github.com/supabase/server/commit/4053f6d8db89201a239190a025b08cf19083acb4))
-* set initial release version ([8352bda](https://github.com/supabase/server/commit/8352bda35c5967a6692f0a21744d30793e10709a))
-* standardize error response ([#18](https://github.com/supabase/server/issues/18)) ([a7ddb74](https://github.com/supabase/server/commit/a7ddb74bfbbe4565d461be7df7f01e64854f6c06))
-
+- add `supabaseOptions` and refactor client creation to options objects ([#19](https://github.com/supabase/server/issues/19)) ([5a10099](https://github.com/supabase/server/commit/5a100995a1b6254f92768c82c74b1c754c29b3b2))
+- exposing `keyName` to `SupabaseContext` ([#22](https://github.com/supabase/server/issues/22)) ([7f1b1a7](https://github.com/supabase/server/commit/7f1b1a75cc98d08a63275131481e5df825c10afb))
+- implement server-side DX primitives, wrappers, and adapters ([#6](https://github.com/supabase/server/issues/6)) ([d206e5c](https://github.com/supabase/server/commit/d206e5cdb102bf96e0c501b72e7f161cbf9fba0c))
+- passing down Database generic type to `createClient` ([#16](https://github.com/supabase/server/issues/16)) ([4053f6d](https://github.com/supabase/server/commit/4053f6d8db89201a239190a025b08cf19083acb4))
+- set initial release version ([8352bda](https://github.com/supabase/server/commit/8352bda35c5967a6692f0a21744d30793e10709a))
+- standardize error response ([#18](https://github.com/supabase/server/issues/18)) ([a7ddb74](https://github.com/supabase/server/commit/a7ddb74bfbbe4565d461be7df7f01e64854f6c06))
 
 ### Bug Fixes
 
-* key name resolution for client creation ([#9](https://github.com/supabase/server/issues/9)) ([e17bd4e](https://github.com/supabase/server/commit/e17bd4ecb1c46d0dc1468f363c884090d78ae86a))
-* move SKILL.md into skills/ subdirectory to align with agentskills spec ([#24](https://github.com/supabase/server/issues/24)) ([10c8780](https://github.com/supabase/server/commit/10c8780cc21de3bb860d2ec8bf5589f69d4ea447))
-* release action ([#29](https://github.com/supabase/server/issues/29)) ([91580d1](https://github.com/supabase/server/commit/91580d11fd1217a22da1150757114ee980d6157b))
-* remove provenance until repo is public ([2ebbc71](https://github.com/supabase/server/commit/2ebbc71e214c4bbae62c6af203a039801b5e3d4d))
-* removing `core` lib exports from root index ([#17](https://github.com/supabase/server/issues/17)) ([5e53e3c](https://github.com/supabase/server/commit/5e53e3c14fcc7c198f1c0bbec9089b4aedd91473))
-* support bare array format for SUPABASE_JWKS ([#8](https://github.com/supabase/server/issues/8)) ([6bd2e4d](https://github.com/supabase/server/commit/6bd2e4dfc1b60ce4cc8a1b59435b87797e1cb017))
+- key name resolution for client creation ([#9](https://github.com/supabase/server/issues/9)) ([e17bd4e](https://github.com/supabase/server/commit/e17bd4ecb1c46d0dc1468f363c884090d78ae86a))
+- move SKILL.md into skills/ subdirectory to align with agentskills spec ([#24](https://github.com/supabase/server/issues/24)) ([10c8780](https://github.com/supabase/server/commit/10c8780cc21de3bb860d2ec8bf5589f69d4ea447))
+- release action ([#29](https://github.com/supabase/server/issues/29)) ([91580d1](https://github.com/supabase/server/commit/91580d11fd1217a22da1150757114ee980d6157b))
+- remove provenance until repo is public ([2ebbc71](https://github.com/supabase/server/commit/2ebbc71e214c4bbae62c6af203a039801b5e3d4d))
+- removing `core` lib exports from root index ([#17](https://github.com/supabase/server/issues/17)) ([5e53e3c](https://github.com/supabase/server/commit/5e53e3c14fcc7c198f1c0bbec9089b4aedd91473))
+- support bare array format for SUPABASE_JWKS ([#8](https://github.com/supabase/server/issues/8)) ([6bd2e4d](https://github.com/supabase/server/commit/6bd2e4dfc1b60ce4cc8a1b59435b87797e1cb017))
 
 ## [0.1.3](https://github.com/supabase/server/compare/server-v0.1.2...server-v0.1.3) (2026-04-01)
 
-
 ### Bug Fixes
 
-* move SKILL.md into skills/ subdirectory to align with agentskills spec ([#24](https://github.com/supabase/server/issues/24)) ([10c8780](https://github.com/supabase/server/commit/10c8780cc21de3bb860d2ec8bf5589f69d4ea447))
+- move SKILL.md into skills/ subdirectory to align with agentskills spec ([#24](https://github.com/supabase/server/issues/24)) ([10c8780](https://github.com/supabase/server/commit/10c8780cc21de3bb860d2ec8bf5589f69d4ea447))
 
 ## [0.1.2](https://github.com/supabase/server/compare/server-v0.1.1...server-v0.1.2) (2026-04-01)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 > **Beta:** This package is under active development. APIs and documentation may change. If you find a bug or have a feature request, please [open an issue](https://github.com/supabase/server/issues) or [submit a PR](https://github.com/supabase/server/blob/main/CONTRIBUTING.md).
 
+> **Heads up — `allow` is now `auth`.** The `allow` config option has been renamed to `auth` to better align with CLI terminology and read more naturally (e.g. `auth: 'user'`). The old `allow` key still works but is deprecated and will emit a one-time `console.warn` per process. It will be removed in a future major release. **Migration:** find-and-replace `allow:` → `auth:` in your `withSupabase`, `createSupabaseContext`, `verifyAuth`, and `verifyCredentials` calls.
+
 `@supabase/server` gives you batteries included access to the
 [supabase-js SDK](https://github.com/supabase/supabase-js), including client
 creation and authentication automatically scoped to the inbound requests to your
@@ -15,7 +17,7 @@ Edge Functions and APIs.
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     // RLS-scoped — this user only sees their own favorites
     const { data: myGames } = await ctx.supabase.from('favorite_games').select()
     return Response.json(myGames)
@@ -55,7 +57,7 @@ Imagine you're building an app where users track their favorite games. They sign
 ```ts
 // A signed-in user fetches their favorite games.
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     const { supabase, supabaseAdmin, userClaims, claims, authType } = ctx
     // supabase       — RLS-scoped to the authenticated user
     // supabaseAdmin  — bypasses RLS (service role)
@@ -74,9 +76,9 @@ export default {
 
 ```ts
 // The frontend hits this before showing the login screen.
-// allow: 'always' means no credentials required.
+// auth: 'always' means no credentials required.
 export default {
-  fetch: withSupabase({ allow: 'always' }, async (_req, _ctx) => {
+  fetch: withSupabase({ auth: 'always' }, async (_req, _ctx) => {
     return Response.json({ status: 'ok' })
   }),
 }
@@ -88,7 +90,7 @@ export default {
 // An admin dashboard fetches the list of featured games to curate.
 // Secret key auth (not a user JWT) — supabaseAdmin bypasses RLS.
 export default {
-  fetch: withSupabase({ allow: 'secret' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'secret' }, async (_req, ctx) => {
     const { data: featuredGames } = await ctx.supabaseAdmin
       .from('featured_games')
       .select()
@@ -103,7 +105,7 @@ export default {
 // Users view their own play stats from the app (JWT).
 // A backend service pulls stats for any user (secret key + user_id in body).
 export default {
-  fetch: withSupabase({ allow: ['user', 'secret'] }, async (req, ctx) => {
+  fetch: withSupabase({ auth: ['user', 'secret'] }, async (req, ctx) => {
     const callerIsUser = ctx.authType === 'user'
 
     if (callerIsUser) {
@@ -129,7 +131,7 @@ export default {
 // A cron job refreshes the "popular this week" list every hour.
 // Named key ("cron") so it can be rotated without touching other services.
 export default {
-  fetch: withSupabase({ allow: 'secret:cron' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'secret:cron' }, async (_req, ctx) => {
     const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
     const { data: popularThisWeek } = await ctx.supabaseAdmin.rpc(
       'get_most_favorited_since',
@@ -167,11 +169,11 @@ await fetch(refreshEndpoint, {
 | `"secret"`         | Valid secret key      | Server-to-server, internal calls                    |
 | `"always"`         | None                  | Open endpoints, wrappers that handle their own auth |
 
-Array syntax (`allow: ["user", "secret"]`) accepts multiple auth methods — first match wins. An absent credential falls through to the next mode; a present-but-invalid JWT rejects the request (no silent downgrade). See [`docs/auth-modes.md`](docs/auth-modes.md).
+Array syntax (`auth: ["user", "secret"]`) accepts multiple auth methods — first match wins. An absent credential falls through to the next mode; a present-but-invalid JWT rejects the request (no silent downgrade). See [`docs/auth-modes.md`](docs/auth-modes.md).
 
-Named key validation: `allow: "public:web_app"` or `allow: "secret:automations"` validates against a specific named key in `SUPABASE_PUBLISHABLE_KEYS` or `SUPABASE_SECRET_KEYS`.
+Named key validation: `auth: "public:web_app"` or `auth: "secret:automations"` validates against a specific named key in `SUPABASE_PUBLISHABLE_KEYS` or `SUPABASE_SECRET_KEYS`.
 
-> **Supabase Edge Functions:** By default, the platform requires a valid JWT on every request. If your function uses `allow: 'public'`, `allow: 'secret'`, or `allow: 'always'`, disable the platform-level JWT check in `supabase/config.toml`:
+> **Supabase Edge Functions:** By default, the platform requires a valid JWT on every request. If your function uses `auth: 'public'`, `auth: 'secret'`, or `auth: 'always'`, disable the platform-level JWT check in `supabase/config.toml`:
 >
 > ```toml
 > [functions.my-function]
@@ -202,7 +204,7 @@ interface SupabaseContext {
 ```ts
 withSupabase(
   {
-    allow: 'user', // who can call this function
+    auth: 'user', // who can call this function
     cors: false, // disable CORS (default: supabase-js CORS headers)
     env: { url: '...' }, // env overrides (optional)
   },
@@ -215,7 +217,7 @@ withSupabase(
 ```ts
 withSupabase(
   {
-    allow: 'user',
+    auth: 'user',
     cors: {
       'Access-Control-Allow-Origin': 'https://myapp.com',
       'Access-Control-Allow-Headers': 'authorization, content-type',
@@ -238,7 +240,7 @@ import { withSupabase } from '@supabase/server/adapters/hono'
 const app = new Hono()
 
 // Protected — withSupabase middleware validates the JWT before the handler runs
-app.get('/games', withSupabase({ allow: 'user' }), async (c) => {
+app.get('/games', withSupabase({ auth: 'user' }), async (c) => {
   const { supabase } = c.var.supabaseContext
   const { data: myGames } = await supabase.from('favorite_games').select()
   return c.json(myGames)
@@ -261,7 +263,7 @@ import { withSupabase } from '@supabase/server/adapters/h3'
 const app = new H3()
 
 // Protected — withSupabase validates the JWT before the handler runs
-app.use(withSupabase({ allow: 'user' }))
+app.use(withSupabase({ auth: 'user' }))
 
 app.get('/games', async (event) => {
   const { supabase } = event.context.supabaseContext
@@ -283,7 +285,7 @@ import { defineHandler } from 'h3'
 import { withSupabase } from '@supabase/server/adapters/h3'
 
 export default defineHandler({
-  middleware: [withSupabase({ allow: 'user' })],
+  middleware: [withSupabase({ auth: 'user' })],
   handler: async (event) => {
     const { supabase } = event.context.supabaseContext
     return supabase.from('favorite_games').select()
@@ -297,7 +299,7 @@ For app-wide auth, register it as a server middleware:
 // server/middleware/supabase.ts
 import { withSupabase } from '@supabase/server/adapters/h3'
 
-export default withSupabase({ allow: 'user' })
+export default withSupabase({ auth: 'user' })
 ```
 
 The adapter does not handle CORS — use H3's CORS utilities for that.
@@ -318,10 +320,10 @@ import {
 
 ### verifyAuth
 
-Extracts credentials from a Request and validates against the allow config.
+Extracts credentials from a Request and validates against the auth config.
 
 ```ts
-const { data: auth, error } = await verifyAuth(req, { allow: 'user' })
+const { data: auth, error } = await verifyAuth(req, { auth: 'user' })
 if (error) {
   return Response.json({ message: error.message }, { status: error.status })
 }
@@ -333,8 +335,8 @@ Low-level — works with raw credentials instead of a Request. Used by SSR adapt
 
 ```ts
 const credentials = { token: myToken, apikey: null }
-const { data: auth, error } = await verifyCredentials(credentials, {
-  allow: 'user',
+const { data: result, error } = await verifyCredentials(credentials, {
+  auth: 'user',
 })
 ```
 
@@ -351,7 +353,7 @@ const adminClient = createAdminClient() // bypasses RLS entirely
 Full context assembly from a Request — `verifyAuth` + client creation in one call.
 
 ```ts
-const { data: ctx, error } = await createSupabaseContext(req, { allow: 'user' })
+const { data: ctx, error } = await createSupabaseContext(req, { auth: 'user' })
 ```
 
 ### resolveEnv
@@ -382,14 +384,14 @@ export default {
 
     // Protected — verify the JWT, then create a user-scoped client
     if (url.pathname === '/games') {
-      const { data: auth, error } = await verifyAuth(req, { allow: 'user' })
+      const { data: result, error } = await verifyAuth(req, { auth: 'user' })
       if (error)
         return Response.json(
           { message: error.message },
           { status: error.status },
         )
 
-      const userScopedClient = createContextClient(auth.token)
+      const userScopedClient = createContextClient(result.token)
       const { data: myGames } = await userScopedClient
         .from('favorite_games')
         .select()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,7 +18,7 @@ function withSupabase<Database = unknown>(
 Wraps a fetch handler with auth, CORS, and client creation. Returns a `(req: Request) => Promise<Response>` function suitable for `export default { fetch }`.
 
 - Handles `OPTIONS` preflight when CORS is enabled
-- Verifies credentials per `config.allow`
+- Verifies credentials per `config.auth`
 - Returns JSON error response on auth failure
 - Adds CORS headers to all responses
 
@@ -36,7 +36,7 @@ function createSupabaseContext<Database = unknown>(
 
 Creates a `SupabaseContext` from a request. Returns a result tuple. The `cors` option is ignored.
 
-Defaults to `allow: 'user'` when `options` is omitted.
+Defaults to `auth: 'user'` when `options` is omitted.
 
 ---
 
@@ -47,7 +47,10 @@ Defaults to `allow: 'user'` when `options` is omitted.
 ```ts
 function verifyAuth(
   request: Request,
-  options: { allow: AllowWithKey | AllowWithKey[]; env?: Partial<SupabaseEnv> },
+  options: {
+    auth?: AuthModeWithKey | AuthModeWithKey[]
+    env?: Partial<SupabaseEnv>
+  },
 ): Promise<{ data: AuthResult; error: null } | { data: null; error: AuthError }>
 ```
 
@@ -58,7 +61,10 @@ Extracts credentials from a request and verifies them. Convenience wrapper over 
 ```ts
 function verifyCredentials(
   credentials: Credentials,
-  options: { allow: AllowWithKey | AllowWithKey[]; env?: Partial<SupabaseEnv> },
+  options: {
+    auth?: AuthModeWithKey | AuthModeWithKey[]
+    env?: Partial<SupabaseEnv>
+  },
 ): Promise<{ data: AuthResult; error: null } | { data: null; error: AuthError }>
 ```
 
@@ -124,25 +130,29 @@ Hono middleware. Sets `c.var.supabaseContext` on the Hono context. Throws `HTTPE
 
 Skips if `c.var.supabaseContext` is already set (enables route-level overrides).
 
-Defaults to `allow: 'user'` when config is omitted.
+Defaults to `auth: 'user'` when config is omitted.
 
 ---
 
 ## Types
 
-### Allow
+### AuthMode
 
 ```ts
-type Allow = 'always' | 'public' | 'secret' | 'user'
+type AuthMode = 'always' | 'public' | 'secret' | 'user'
 ```
 
-### AllowWithKey
+### AuthModeWithKey
 
 ```ts
-type AllowWithKey = Allow | `public:${string}` | `secret:${string}`
+type AuthModeWithKey = AuthMode | `public:${string}` | `secret:${string}`
 ```
 
 Extended auth mode with named key support. Examples: `'public:web'`, `'secret:*'`, `'secret:internal'`.
+
+### Allow / AllowWithKey (deprecated aliases)
+
+`Allow` and `AllowWithKey` are kept as deprecated aliases for `AuthMode` and `AuthModeWithKey`. Prefer the `Auth*` names — the legacy ones will be removed in a future major release.
 
 ### SupabaseContext\<Database\>
 
@@ -152,7 +162,7 @@ interface SupabaseContext<Database = unknown> {
   supabaseAdmin: SupabaseClient<Database>
   userClaims: UserClaims | null
   claims: JWTClaims | null
-  authType: Allow
+  authType: AuthMode
 }
 ```
 
@@ -160,7 +170,9 @@ interface SupabaseContext<Database = unknown> {
 
 ```ts
 interface WithSupabaseConfig {
-  allow?: AllowWithKey | AllowWithKey[] // default: 'user'
+  auth?: AuthModeWithKey | AuthModeWithKey[] // default: 'user'
+  /** @deprecated use `auth` instead — will be removed in a future major release */
+  allow?: AuthModeWithKey | AuthModeWithKey[]
   env?: Partial<SupabaseEnv>
   cors?: boolean | Record<string, string> // default: true
   supabaseOptions?: SupabaseClientOptions<string>
@@ -191,7 +203,7 @@ interface Credentials {
 
 ```ts
 interface AuthResult {
-  authType: Allow
+  authType: AuthMode
   token: string | null
   userClaims: UserClaims | null
   claims: JWTClaims | null

--- a/docs/auth-modes.md
+++ b/docs/auth-modes.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Every request is validated against one or more auth modes before your handler runs. The `allow` config determines which modes are accepted.
+Every request is validated against one or more auth modes before your handler runs. The `auth` config determines which modes are accepted.
+
+> **`allow` is deprecated.** The `auth` option replaces the legacy `allow` option. `allow` still works (with a one-time `console.warn`) but will be removed in a future major release. Migration is a find-and-replace: `allow:` → `auth:`.
 
 | Mode       | Credential required                          | Typical use case                       |
 | ---------- | -------------------------------------------- | -------------------------------------- |
@@ -27,7 +29,7 @@ The default. Verifies the JWT using your project's JWKS (JSON Web Key Set).
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     // ctx.userClaims has the caller's identity
     console.log(ctx.userClaims!.id) // "d0f1a2b3-..."
     console.log(ctx.userClaims!.email) // "user@example.com"
@@ -60,7 +62,7 @@ Validates that the `apikey` header contains a recognized publishable key. Uses t
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'public' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'public' }, async (_req, ctx) => {
     // ctx.userClaims is null — no JWT involved
     // ctx.supabase is initialized as anonymous (RLS anon role)
     const { data } = await ctx.supabase.from('products').select()
@@ -85,7 +87,7 @@ Validates that the `apikey` header contains a recognized secret key. Same timing
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'secret' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'secret' }, async (_req, ctx) => {
     // ctx.supabaseAdmin bypasses RLS — use for privileged operations
     const { data } = await ctx.supabaseAdmin.from('config').select()
     return Response.json(data)
@@ -107,7 +109,7 @@ No credentials required. Every request is accepted.
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'always' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'always' }, async (_req, ctx) => {
     // ctx.authType is 'always'
     // ctx.userClaims is null
     // ctx.supabase is anonymous (RLS anon role)
@@ -126,7 +128,7 @@ Accept multiple auth methods. Modes are tried in order — the first match wins.
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: ['user', 'secret'] }, async (req, ctx) => {
+  fetch: withSupabase({ auth: ['user', 'secret'] }, async (req, ctx) => {
     // ctx.authType tells you which mode matched
     if (ctx.authType === 'user') {
       // Called by an authenticated user
@@ -167,20 +169,20 @@ Keys are stored as a JSON object in `SUPABASE_PUBLISHABLE_KEYS` or `SUPABASE_SEC
 
 ```ts
 // Only accept the "web" publishable key
-withSupabase({ allow: 'public:web' }, handler)
+withSupabase({ auth: 'public:web' }, handler)
 
 // Only accept the "internal" secret key
-withSupabase({ allow: 'secret:internal' }, handler)
+withSupabase({ auth: 'secret:internal' }, handler)
 ```
 
 ### Wildcard — accept any key in the set
 
 ```ts
 // Accept any publishable key
-withSupabase({ allow: 'public:*' }, handler)
+withSupabase({ auth: 'public:*' }, handler)
 
 // Accept any secret key
-withSupabase({ allow: 'secret:*' }, handler)
+withSupabase({ auth: 'secret:*' }, handler)
 ```
 
 ### Which key matched?
@@ -190,7 +192,7 @@ When using named keys, `ctx.authType` tells you the mode and `keyName` on the `A
 ### Combining named keys with other modes
 
 ```ts
-withSupabase({ allow: ['user', 'public:web'] }, async (_req, ctx) => {
+withSupabase({ auth: ['user', 'public:web'] }, async (_req, ctx) => {
   // Accepts either a valid JWT or the "web" publishable key
   return Response.json({ authType: ctx.authType })
 })
@@ -199,7 +201,7 @@ withSupabase({ allow: ['user', 'public:web'] }, async (_req, ctx) => {
 ## How auth flows through the system
 
 1. `extractCredentials(request)` reads `Authorization: Bearer <token>` and `apikey` from headers
-2. Each mode in `allow` is tried in order against the extracted credentials
+2. Each mode in `auth` is tried in order against the extracted credentials
 3. First match wins — returns an `AuthResult` with `authType`, `token`, `userClaims`, `claims`, and `keyName`. A mode falls through to the next only when its credential is absent; a credential that is present but invalid terminates the chain with `InvalidCredentialsError`.
 4. The auth result is used to create scoped clients (`supabase` with the user's token, `supabaseAdmin` with the secret key)
 5. Everything is bundled into a `SupabaseContext` and passed to your handler

--- a/docs/core-primitives.md
+++ b/docs/core-primitives.md
@@ -77,7 +77,7 @@ import { verifyCredentials } from '@supabase/server/core'
 
 const credentials = { token: cookieToken, apikey: null }
 const { data: auth, error } = await verifyCredentials(credentials, {
-  allow: 'user',
+  auth: 'user',
 })
 
 if (error) {
@@ -93,17 +93,17 @@ Supports all auth mode syntax — single mode, arrays, and named keys:
 ```ts
 // Multiple modes
 const { data: auth } = await verifyCredentials(creds, {
-  allow: ['user', 'public'],
+  auth: ['user', 'public'],
 })
 
 // Named key
 const { data: auth } = await verifyCredentials(creds, {
-  allow: 'public:web',
+  auth: 'public:web',
 })
 
 // Wildcard
 const { data: auth } = await verifyCredentials(creds, {
-  allow: 'secret:*',
+  auth: 'secret:*',
 })
 ```
 
@@ -115,7 +115,7 @@ Convenience function that combines `extractCredentials` and `verifyCredentials` 
 import { verifyAuth } from '@supabase/server/core'
 
 const { data: auth, error } = await verifyAuth(request, {
-  allow: 'user',
+  auth: 'user',
 })
 
 if (error) {
@@ -134,7 +134,7 @@ Creates a Supabase client scoped to the caller's identity. RLS policies apply.
 import { verifyAuth, createContextClient } from '@supabase/server/core'
 
 // With a user's token (from verifyAuth)
-const { data: auth } = await verifyAuth(request, { allow: 'user' })
+const { data: auth } = await verifyAuth(request, { auth: 'user' })
 const supabase = createContextClient({
   auth: { token: auth!.token, keyName: auth!.keyName },
 })
@@ -194,7 +194,7 @@ export default {
 
     // User-authenticated route
     if (url.pathname === '/todos') {
-      const { data: auth, error } = await verifyAuth(req, { allow: 'user' })
+      const { data: auth, error } = await verifyAuth(req, { auth: 'user' })
       if (error) {
         return Response.json(
           { message: error.message },
@@ -212,7 +212,7 @@ export default {
     // Admin route — secret key only
     if (url.pathname === '/admin/users') {
       const { data: auth, error } = await verifyAuth(req, {
-        allow: 'secret',
+        auth: 'secret',
       })
       if (error) {
         return Response.json(

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -15,12 +15,12 @@ On Supabase Platform and Local Development (CLI), all variables are auto-provisi
 
 Set these based on which auth modes your app uses:
 
-| Variable                   | Required when                              |
-| -------------------------- | ------------------------------------------ |
-| `SUPABASE_URL`             | Always                                     |
-| `SUPABASE_SECRET_KEY`      | `allow: 'secret'` or using `supabaseAdmin` |
-| `SUPABASE_PUBLISHABLE_KEY` | `allow: 'public'`                          |
-| `SUPABASE_JWKS`            | `allow: 'user'` (JWT verification)         |
+| Variable                   | Required when                             |
+| -------------------------- | ----------------------------------------- |
+| `SUPABASE_URL`             | Always                                    |
+| `SUPABASE_SECRET_KEY`      | `auth: 'secret'` or using `supabaseAdmin` |
+| `SUPABASE_PUBLISHABLE_KEY` | `auth: 'public'`                          |
+| `SUPABASE_JWKS`            | `auth: 'user'` (JWT verification)         |
 
 ### Minimal `.env` example
 
@@ -48,10 +48,10 @@ You can then validate against specific keys with named key syntax:
 
 ```ts
 // Only accept the "web" publishable key
-withSupabase({ allow: 'public:web' }, handler)
+withSupabase({ auth: 'public:web' }, handler)
 
 // Accept any secret key
-withSupabase({ allow: 'secret:*' }, handler)
+withSupabase({ auth: 'secret:*' }, handler)
 ```
 
 ### Singular form — equivalent to a single "default" key
@@ -69,7 +69,7 @@ SUPABASE_PUBLISHABLE_KEY=sb_publishable_default_abc
 SUPABASE_PUBLISHABLE_KEYS={"default":"sb_publishable_default_abc"}
 ```
 
-The singular form is a convenience for the common case where you only have one key. The SDK stores it internally as `{ default: "<value>" }`, so `allow: 'public'` (which looks for the `"default"` key) works with both forms.
+The singular form is a convenience for the common case where you only have one key. The SDK stores it internally as `{ default: "<value>" }`, so `auth: 'public'` (which looks for the `"default"` key) works with both forms.
 
 ### Priority
 
@@ -87,7 +87,7 @@ SUPABASE_JWKS={"keys":[{"kty":"RSA","n":"...","e":"AQAB"}]}
 SUPABASE_JWKS=[{"kty":"RSA","n":"...","e":"AQAB"}]
 ```
 
-When `SUPABASE_JWKS` is not set, JWT verification (`allow: 'user'`) is unavailable.
+When `SUPABASE_JWKS` is not set, JWT verification (`auth: 'user'`) is unavailable.
 
 ## Runtime-specific behavior
 
@@ -119,7 +119,7 @@ Cloudflare Workers don't expose `Deno.env` or `process.env` by default. Two opti
    ```ts
    withSupabase(
      {
-       allow: 'user',
+       auth: 'user',
        env: {
          url: env.SUPABASE_URL,
          publishableKeys: { default: env.SUPABASE_PUBLISHABLE_KEY },
@@ -140,7 +140,7 @@ import { withSupabase } from '@supabase/server'
 export default {
   fetch: withSupabase(
     {
-      allow: 'user',
+      auth: 'user',
       env: {
         url: 'http://localhost:54321', // override just the URL
       },

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -62,7 +62,7 @@ import { createSupabaseContext } from '@supabase/server'
 export default {
   fetch: async (req: Request) => {
     const { data: ctx, error } = await createSupabaseContext(req, {
-      allow: 'user',
+      auth: 'user',
     })
 
     if (error) {
@@ -93,7 +93,7 @@ import { withSupabase } from '@supabase/server/adapters/hono'
 
 const app = new Hono()
 
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 app.onError((err, c) => {
   if (err instanceof HTTPException && err.cause) {
@@ -115,7 +115,7 @@ Result-tuple functions:
 import { verifyAuth, resolveEnv } from '@supabase/server/core'
 
 // verifyAuth returns { data, error }
-const { data: auth, error } = await verifyAuth(request, { allow: 'user' })
+const { data: auth, error } = await verifyAuth(request, { auth: 'user' })
 if (error) {
   return Response.json({ message: error.message }, { status: error.status })
 }
@@ -137,7 +137,7 @@ import {
 } from '@supabase/server/core'
 import { EnvError } from '@supabase/server'
 
-const { data: auth, error } = await verifyAuth(request, { allow: 'user' })
+const { data: auth, error } = await verifyAuth(request, { auth: 'user' })
 // ... handle error ...
 
 try {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ The fastest way to get a working authenticated endpoint:
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     const { data } = await ctx.supabase.from('todos').select()
     return Response.json(data)
   }),
@@ -56,13 +56,13 @@ Your handler only runs when auth succeeds.
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'always' }, async (_req, _ctx) => {
+  fetch: withSupabase({ auth: 'always' }, async (_req, _ctx) => {
     return Response.json({ status: 'ok', time: new Date().toISOString() })
   }),
 }
 ```
 
-> **Supabase Edge Functions:** By default, the platform requires a valid JWT on every request. If your function uses `allow: 'public'`, `allow: 'secret'`, or `allow: 'always'`, disable the platform-level JWT check in `supabase/config.toml`:
+> **Supabase Edge Functions:** By default, the platform requires a valid JWT on every request. If your function uses `auth: 'public'`, `auth: 'secret'`, or `auth: 'always'`, disable the platform-level JWT check in `supabase/config.toml`:
 >
 > ```toml
 > [functions.my-function]
@@ -79,7 +79,7 @@ Every handler receives a `SupabaseContext` with these fields:
 | `supabaseAdmin` | `SupabaseClient`     | Admin client. Bypasses RLS.                                                                            |
 | `userClaims`    | `UserClaims \| null` | JWT-derived identity (`id`, `email`, `role`, `appMetadata`, `userMetadata`). `null` for non-user auth. |
 | `claims`        | `JWTClaims \| null`  | Raw JWT payload (snake_case). `null` for non-user auth.                                                |
-| `authType`      | `Allow`              | Which auth mode matched: `'user'`, `'public'`, `'secret'`, or `'always'`.                              |
+| `authType`      | `AuthMode`           | Which auth mode matched: `'user'`, `'public'`, `'secret'`, or `'always'`.                              |
 | `authKeyName`   | `string \| null`     | Which auth key name of the API key that was used.                                                      |
 
 The `supabase` client respects Row-Level Security. When `authType` is `'user'`, the client is scoped to that user's permissions. For other auth modes, it's initialized as anonymous.
@@ -98,7 +98,7 @@ import { createSupabaseContext } from '@supabase/server'
 export default {
   fetch: async (req: Request) => {
     const { data: ctx, error } = await createSupabaseContext(req, {
-      allow: 'user',
+      auth: 'user',
     })
 
     if (error) {
@@ -124,7 +124,7 @@ CORS is enabled by default with standard supabase-js headers. You can customize 
 // Custom CORS headers
 withSupabase(
   {
-    allow: 'user',
+    auth: 'user',
     cors: {
       'Access-Control-Allow-Origin': 'https://myapp.com',
       'Access-Control-Allow-Headers': 'authorization, content-type',
@@ -134,7 +134,7 @@ withSupabase(
 )
 
 // Disable CORS (e.g., when a framework handles it)
-withSupabase({ allow: 'user', cors: false }, handler)
+withSupabase({ auth: 'user', cors: false }, handler)
 ```
 
 ## Runtimes

--- a/docs/hono-adapter.md
+++ b/docs/hono-adapter.md
@@ -19,7 +19,7 @@ import { withSupabase } from '@supabase/server/adapters/hono'
 const app = new Hono()
 
 // Apply auth to all routes
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 app.get('/todos', async (c) => {
   const { supabase } = c.var.supabaseContext
@@ -55,14 +55,14 @@ const app = new Hono()
 app.get('/health', (c) => c.json({ status: 'ok' }))
 
 // User-authenticated route
-app.get('/todos', withSupabase({ allow: 'user' }), async (c) => {
+app.get('/todos', withSupabase({ auth: 'user' }), async (c) => {
   const { supabase } = c.var.supabaseContext
   const { data } = await supabase.from('todos').select()
   return c.json(data)
 })
 
 // Secret-key-protected admin route
-app.post('/admin/sync', withSupabase({ allow: 'secret' }), async (c) => {
+app.post('/admin/sync', withSupabase({ auth: 'secret' }), async (c) => {
   const { supabaseAdmin } = c.var.supabaseContext
   const { data } = await supabaseAdmin
     .from('audit_log')
@@ -71,7 +71,7 @@ app.post('/admin/sync', withSupabase({ allow: 'secret' }), async (c) => {
 })
 
 // Dual auth — users or services
-app.get('/reports', withSupabase({ allow: ['user', 'secret'] }), async (c) => {
+app.get('/reports', withSupabase({ auth: ['user', 'secret'] }), async (c) => {
   const { supabase, authType } = c.var.supabaseContext
   return c.json({ authType })
 })
@@ -87,12 +87,12 @@ If a previous middleware already set `c.var.supabaseContext`, subsequent `withSu
 const app = new Hono()
 
 // App-wide: require user auth
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 // This route needs secret auth instead.
 // The route-level middleware runs first, sets the context,
 // and the app-wide middleware skips.
-app.post('/webhook', withSupabase({ allow: 'secret' }), async (c) => {
+app.post('/webhook', withSupabase({ auth: 'secret' }), async (c) => {
   const { supabaseAdmin } = c.var.supabaseContext
   // ...
 })
@@ -110,7 +110,7 @@ import { withSupabase } from '@supabase/server/adapters/hono'
 const app = new Hono()
 
 app.use('*', cors())
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 app.get('/todos', async (c) => {
   const { supabase } = c.var.supabaseContext
@@ -133,7 +133,7 @@ import { AuthError } from '@supabase/server'
 
 const app = new Hono()
 
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 // Custom error handler
 app.onError((err, c) => {
@@ -164,7 +164,7 @@ Pass `env` to override auto-detected environment variables, same as the main wra
 app.use(
   '*',
   withSupabase({
-    allow: 'user',
+    auth: 'user',
     env: { url: 'http://localhost:54321' },
   }),
 )
@@ -178,7 +178,7 @@ Forward options to the underlying `createClient()` calls:
 app.use(
   '*',
   withSupabase({
-    allow: 'user',
+    auth: 'user',
     supabaseOptions: { db: { schema: 'api' } },
   }),
 )

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,8 +12,8 @@ The package uses a **double-HMAC technique**: both strings are HMAC'd with a ran
 
 This applies to:
 
-- **Publishable key verification** (`allow: 'public'`) — compares the `apikey` header against stored publishable keys
-- **Secret key verification** (`allow: 'secret'`) — compares the `apikey` header against stored secret keys
+- **Publishable key verification** (`auth: 'public'`) — compares the `apikey` header against stored publishable keys
+- **Secret key verification** (`auth: 'secret'`) — compares the `apikey` header against stored secret keys
 
 See `src/core/utils/timing-safe-equal.ts` for the implementation.
 
@@ -31,7 +31,7 @@ Each auth mode provides a different level of trust:
 Key implications:
 
 - **`user` mode** verifies the JWT using a local JWKS (JSON Web Key Set). The token must contain a `sub` claim. Verification uses the `jose` library's `jwtVerify` with a local key set — no network calls to an auth server.
-- **`public` and `secret` modes** compare the `apikey` header against known keys. The comparison is timing-safe. If you use named keys (`allow: 'secret:automations'`), only that specific key is accepted — this follows the principle of least privilege.
+- **`public` and `secret` modes** compare the `apikey` header against known keys. The comparison is timing-safe. If you use named keys (`auth: 'secret:automations'`), only that specific key is accepted — this follows the principle of least privilege.
 - **`always` mode** performs zero authentication. The handler runs for every request. The `supabaseAdmin` client is still available, so a compromised `always` endpoint with write operations is a security risk. Only use it for truly public endpoints or when you implement your own auth (e.g., webhook signature verification).
 
 ## Named key isolation
@@ -40,10 +40,10 @@ Instead of accepting any valid API key, you can restrict an endpoint to a specif
 
 ```ts
 // Accepts any secret key
-withSupabase({ allow: 'secret' }, handler)
+withSupabase({ auth: 'secret' }, handler)
 
 // Only accepts the "automations" secret key
-withSupabase({ allow: 'secret:automations' }, handler)
+withSupabase({ auth: 'secret:automations' }, handler)
 ```
 
 This limits the blast radius if a key is compromised. An attacker with the `web` publishable key cannot access an endpoint that requires `secret:automations`. Named keys also make it easier to rotate or revoke access for a specific consumer without affecting others.
@@ -60,7 +60,7 @@ JWT verification in `user` mode works as follows:
 
 If JWKS is not configured (`SUPABASE_JWKS` is missing or malformed), `user` mode is unavailable and will always reject requests.
 
-**No silent downgrade.** When `user` is combined with other modes (e.g. `allow: ['user', 'public']`), a JWT that is present but fails verification rejects the request with `InvalidCredentialsError` — it does not fall through to the next mode. This prevents a bad token paired with a valid `apikey` (or with `'always'`) from being silently downgraded to a less-privileged auth mode. Requests that simply omit the `Authorization` header still fall through as expected.
+**No silent downgrade.** When `user` is combined with other modes (e.g. `auth: ['user', 'public']`), a JWT that is present but fails verification rejects the request with `InvalidCredentialsError` — it does not fall through to the next mode. This prevents a bad token paired with a valid `apikey` (or with `'always'`) from being silently downgraded to a less-privileged auth mode. Requests that simply omit the `Authorization` header still fall through as expected.
 
 ## CORS handling
 

--- a/docs/ssr-frameworks.md
+++ b/docs/ssr-frameworks.md
@@ -143,7 +143,7 @@ import {
   createAdminClient,
 } from '@supabase/server/core'
 import type {
-  AllowWithKey,
+  AuthModeWithKey,
   SupabaseContext,
   SupabaseEnv,
 } from '@supabase/server'
@@ -219,7 +219,7 @@ async function getJwks(supabaseUrl: string): Promise<SupabaseEnv['jwks']> {
 }
 
 export async function createSupabaseContext(
-  options: { allow?: AllowWithKey | AllowWithKey[] } = { allow: 'user' },
+  options: { auth?: AuthModeWithKey | AuthModeWithKey[] } = { auth: 'user' },
 ): Promise<
   { data: SupabaseContext; error: null } | { data: null; error: Error }
 > {
@@ -235,9 +235,9 @@ export async function createSupabaseContext(
   const jwks = await getJwks(nextEnv.url)
   const env: Partial<SupabaseEnv> = { ...nextEnv, jwks }
 
-  const { data: auth, error } = await verifyCredentials(
+  const { data: result, error } = await verifyCredentials(
     { token, apikey: null },
-    { allow: options.allow ?? 'user', env },
+    { auth: options.auth ?? 'user', env },
   )
 
   if (error) {
@@ -245,7 +245,7 @@ export async function createSupabaseContext(
   }
 
   const supabase = createContextClient({
-    auth: { token: auth!.token },
+    auth: { token: result!.token },
     env,
   })
   const supabaseAdmin = createAdminClient({ env })
@@ -254,9 +254,9 @@ export async function createSupabaseContext(
     data: {
       supabase,
       supabaseAdmin,
-      userClaims: auth!.userClaims,
-      claims: auth!.claims,
-      authType: auth!.authType,
+      userClaims: result!.userClaims,
+      claims: result!.claims,
+      authType: result!.authType,
     },
     error: null,
   }
@@ -313,10 +313,10 @@ export async function GET() {
 
 ```ts
 // Public endpoint — no auth required
-const { data: ctx } = await createSupabaseContext({ allow: 'always' })
+const { data: ctx } = await createSupabaseContext({ auth: 'always' })
 
 // Accept either user JWT or skip auth
-const { data: ctx } = await createSupabaseContext({ allow: ['user', 'always'] })
+const { data: ctx } = await createSupabaseContext({ auth: ['user', 'always'] })
 ```
 
 ## Adapting for other frameworks

--- a/docs/typescript-generics.md
+++ b/docs/typescript-generics.md
@@ -21,7 +21,7 @@ import { withSupabase } from '@supabase/server'
 import type { Database } from './database.types.ts'
 
 export default {
-  fetch: withSupabase<Database>({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase<Database>({ auth: 'user' }, async (_req, ctx) => {
     // ctx.supabase is SupabaseClient<Database>
     // Fully typed: column names, return type, etc.
     const { data } = await ctx.supabase
@@ -40,7 +40,7 @@ import { createSupabaseContext } from '@supabase/server'
 import type { Database } from './database.types.ts'
 
 const { data: ctx, error } = await createSupabaseContext<Database>(request, {
-  allow: 'user',
+  auth: 'user',
 })
 
 if (error) {
@@ -61,7 +61,7 @@ import {
 } from '@supabase/server/core'
 import type { Database } from './database.types.ts'
 
-const { data: auth } = await verifyAuth(request, { allow: 'user' })
+const { data: auth } = await verifyAuth(request, { auth: 'user' })
 
 const supabase = createContextClient<Database>({
   auth: { token: auth!.token },
@@ -86,7 +86,7 @@ import type { Database } from './database.types.ts'
 
 const app = new Hono()
 
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 app.get('/todos', async (c) => {
   const { supabase } = c.var.supabaseContext as SupabaseContext<Database>
@@ -106,7 +106,7 @@ import type { Database } from './database.types.ts'
 export default {
   fetch: withSupabase<Database>(
     {
-      allow: 'user',
+      auth: 'user',
       supabaseOptions: { db: { schema: 'api' } },
     },
     async (_req, ctx) => {
@@ -128,7 +128,7 @@ export default {
 ```ts
 withSupabase<Database>(
   {
-    allow: 'user',
+    auth: 'user',
     supabaseOptions: {
       db: { schema: 'api' },
       global: {

--- a/skills/supabase-server/SKILL.md
+++ b/skills/supabase-server/SKILL.md
@@ -9,6 +9,8 @@ description: Use when writing server-side code with Supabase — Edge Functions,
 
 > **This is a brand new package.** There is no information available online yet — no blog posts, no Stack Overflow answers, no tutorials. Do not search the web for usage examples. Rely exclusively on the documentation files listed below and the source code in this repository.
 
+> **The config option is `auth`, not `allow`.** `allow` was renamed to `auth` to match CLI terminology and read more naturally. The legacy `allow` key still works (with a one-time `console.warn`) but is deprecated and will be removed in a future major release. **Always emit `auth` in new code** — e.g. `withSupabase({ auth: 'user' }, ...)`. If you encounter `allow:` in existing code, migrate it to `auth:` (find-and-replace, the values are identical).
+
 > **Do not use legacy Supabase keys.** The `anon` key and `service_role` key (env vars `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) are legacy and will be deprecated. Do not use them unless the user explicitly asks. Always use the new API keys:
 >
 > | Legacy (avoid)              | New (use this)                                       |
@@ -16,7 +18,7 @@ description: Use when writing server-side code with Supabase — Edge Functions,
 > | `SUPABASE_ANON_KEY`         | `SUPABASE_PUBLISHABLE_KEY(S)` (`sb_publishable_...`) |
 > | `SUPABASE_SERVICE_ROLE_KEY` | `SUPABASE_SECRET_KEY(S)` (`sb_secret_...`)           |
 >
-> Do not call `createClient(url, anonKey)` directly — use `@supabase/server` auth modes (`allow: 'user'`, `allow: 'secret'`, etc.) which handle key resolution automatically. If migrating existing code, replace `SUPABASE_ANON_KEY` usage with `allow: 'public'` and `SUPABASE_SERVICE_ROLE_KEY` usage with `allow: 'secret'`.
+> Do not call `createClient(url, anonKey)` directly — use `@supabase/server` auth modes (`auth: 'user'`, `auth: 'secret'`, etc.) which handle key resolution automatically. If migrating existing code, replace `SUPABASE_ANON_KEY` usage with `auth: 'public'` and `SUPABASE_SERVICE_ROLE_KEY` usage with `auth: 'secret'`.
 
 Server-side utilities for Supabase. Handles auth, client creation, and context injection so you write business logic, not boilerplate.
 
@@ -24,7 +26,7 @@ Server-side utilities for Supabase. Handles auth, client creation, and context i
 
 - Wraps fetch handlers with credential verification, CORS, and pre-configured Supabase clients
 - Supports 4 auth modes: `user` (JWT), `public` (publishable key), `secret` (secret key), `always` (none)
-- Array syntax (`allow: ['user', 'secret']`) is first-match-wins. A present-but-invalid JWT rejects with `InvalidCredentialsError` — it does not silently downgrade to the next mode.
+- Array syntax (`auth: ['user', 'secret']`) is first-match-wins. A present-but-invalid JWT rejects with `InvalidCredentialsError` — it does not silently downgrade to the next mode.
 - Provides composable core primitives for custom auth flows and framework integration
 - Includes a Hono adapter for per-route auth
 
@@ -38,14 +40,14 @@ Server-side utilities for Supabase. Handles auth, client creation, and context i
 
 ## Quick starts
 
-> **Supabase Edge Functions: disable `verify_jwt` for non-user auth.** By default, Supabase Edge Functions require a valid JWT on every request. If your function uses `allow: 'public'`, `allow: 'secret'`, or `allow: 'always'`, you must disable the platform-level JWT check in `supabase/config.toml`, otherwise the request will be rejected before it reaches your handler:
+> **Supabase Edge Functions: disable `verify_jwt` for non-user auth.** By default, Supabase Edge Functions require a valid JWT on every request. If your function uses `auth: 'public'`, `auth: 'secret'`, or `auth: 'always'`, you must disable the platform-level JWT check in `supabase/config.toml`, otherwise the request will be rejected before it reaches your handler:
 >
 > ```toml
 > [functions.my-function]
 > verify_jwt = false
 > ```
 >
-> Functions using `allow: 'user'` can leave `verify_jwt` enabled (the default) since callers already provide a valid JWT.
+> Functions using `auth: 'user'` can leave `verify_jwt` enabled (the default) since callers already provide a valid JWT.
 
 ### Supabase Edge Functions (Deno)
 
@@ -56,7 +58,7 @@ Environment variables are auto-injected by the platform — zero config. **All i
 import { withSupabase } from 'npm:@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     const { data } = await ctx.supabase.from('todos').select()
     return Response.json(data)
   }),
@@ -70,7 +72,7 @@ import { createSupabaseContext } from 'npm:@supabase/server'
 export default {
   fetch: async (req: Request) => {
     const { data: ctx, error } = await createSupabaseContext(req, {
-      allow: 'user',
+      auth: 'user',
     })
     if (error) {
       return Response.json(
@@ -92,7 +94,7 @@ Requires `nodejs_compat` compatibility flag in `wrangler.toml`, or pass env over
 import { withSupabase } from '@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     const { data } = await ctx.supabase.from('todos').select()
     return Response.json(data)
   }),
@@ -109,7 +111,7 @@ import { Hono } from 'hono'
 import { withSupabase } from '@supabase/server/adapters/hono'
 
 const app = new Hono()
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 app.get('/todos', async (c) => {
   const { supabase } = c.var.supabaseContext
@@ -126,7 +128,7 @@ import { Hono } from 'npm:hono'
 import { withSupabase } from 'npm:@supabase/server/adapters/hono'
 
 const app = new Hono()
-app.use('*', withSupabase({ allow: 'user' }))
+app.use('*', withSupabase({ auth: 'user' }))
 
 app.get('/todos', async (c) => {
   const { supabase } = c.var.supabaseContext
@@ -161,7 +163,7 @@ import { withSupabase } from 'npm:@supabase/server'
 
 // Only accept the "automations" named secret key
 export default {
-  fetch: withSupabase({ allow: 'secret:automations' }, async (req, ctx) => {
+  fetch: withSupabase({ auth: 'secret:automations' }, async (req, ctx) => {
     const body = await req.json()
     const { data } = await ctx.supabaseAdmin
       .from('scheduled_tasks')
@@ -187,26 +189,26 @@ await fetch('https://<project>.supabase.co/functions/v1/my-function', {
 })
 ```
 
-Use `allow: 'secret'` to accept any secret key, or `allow: 'secret:name'` to require a specific named key.
+Use `auth: 'secret'` to accept any secret key, or `auth: 'secret:name'` to require a specific named key.
 
-## When to use `allow: 'always'`
+## When to use `auth: 'always'`
 
-> **`allow: 'always'` disables all authentication.** The handler runs for every request with no credential checks. Only use it when auth is genuinely unnecessary — health checks, public status pages, or endpoints with no sensitive data and no side effects.
+> **`auth: 'always'` disables all authentication.** The handler runs for every request with no credential checks. Only use it when auth is genuinely unnecessary — health checks, public status pages, or endpoints with no sensitive data and no side effects.
 
-**Before using `allow: 'always'`, confirm with the user whether the endpoint is truly public.** If not, propose an alternative:
+**Before using `auth: 'always'`, confirm with the user whether the endpoint is truly public.** If not, propose an alternative:
 
-- **Another service or cron job calls this function** — use `allow: 'secret'` or `allow: 'secret:<name>'` instead. The caller sends the secret key in the `apikey` header.
-- **An external webhook provider calls this function** — use `allow: 'secret'` and have the provider send the secret key, or implement the provider's own signature verification inside the handler.
+- **Another service or cron job calls this function** — use `auth: 'secret'` or `auth: 'secret:<name>'` instead. The caller sends the secret key in the `apikey` header.
+- **An external webhook provider calls this function** — use `auth: 'secret'` and have the provider send the secret key, or implement the provider's own signature verification inside the handler.
 
-**Never use `allow: 'always'` for endpoints that read or write user data without verifying who the caller is.**
+**Never use `auth: 'always'` for endpoints that read or write user data without verifying who the caller is.**
 
-**On `allow: ['user', 'always']`.** A stale or malformed JWT on such an endpoint is rejected with `InvalidCredentialsError` — it is not silently downgraded to anonymous. Callers that might hold a cached/expired token should either omit the `Authorization` header entirely or refresh before calling. If the goal is "anonymous unless a valid user is signed in," this is the correct behavior; if the goal is truly "accept anything," use `allow: 'always'` on its own.
+**On `auth: ['user', 'always']`.** A stale or malformed JWT on such an endpoint is rejected with `InvalidCredentialsError` — it is not silently downgraded to anonymous. Callers that might hold a cached/expired token should either omit the `Authorization` header entirely or refresh before calling. If the goal is "anonymous unless a valid user is signed in," this is the correct behavior; if the goal is truly "accept anything," use `auth: 'always'` on its own.
 
 ## Edge Function recipes
 
 ### Function-to-function calls
 
-One Edge Function can call another using the admin client. The called function uses `allow: 'secret'` and the caller invokes it via `ctx.supabaseAdmin.functions.invoke()`.
+One Edge Function can call another using the admin client. The called function uses `auth: 'secret'` and the caller invokes it via `ctx.supabaseAdmin.functions.invoke()`.
 
 **Config** (`supabase/config.toml`):
 
@@ -221,7 +223,7 @@ verify_jwt = false  # called with secret key, not a user JWT
 import { withSupabase } from 'npm:@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'secret' }, async (req, ctx) => {
+  fetch: withSupabase({ auth: 'secret' }, async (req, ctx) => {
     const { orderId } = await req.json()
     const { data } = await ctx.supabaseAdmin
       .from('orders')
@@ -240,7 +242,7 @@ export default {
 import { withSupabase } from 'npm:@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (req, ctx) => {
     const { orderId } = await req.json()
 
     // Calls process-order with the secret key automatically
@@ -291,11 +293,11 @@ select net.http_post(
 );
 ```
 
-The receiving function uses `allow: 'secret'` (see example above). `pg_net` is asynchronous — the HTTP request is queued and executed in the background. Check `net._http_response` for results.
+The receiving function uses `auth: 'secret'` (see example above). `pg_net` is asynchronous — the HTTP request is queued and executed in the background. Check `net._http_response` for results.
 
 ### Stripe webhook
 
-External webhook providers like Stripe cannot send your Supabase API keys. Use `allow: 'always'` to skip credential checks, then verify the webhook signature inside the handler.
+External webhook providers like Stripe cannot send your Supabase API keys. Use `auth: 'always'` to skip credential checks, then verify the webhook signature inside the handler.
 
 **Config** (`supabase/config.toml`):
 
@@ -320,7 +322,7 @@ import Stripe from 'npm:stripe'
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!)
 
 export default {
-  fetch: withSupabase({ allow: 'always' }, async (req, ctx) => {
+  fetch: withSupabase({ auth: 'always' }, async (req, ctx) => {
     const body = await req.text()
     const sig = req.headers.get('stripe-signature')!
 
@@ -390,14 +392,14 @@ Uses the latest API keys, works across runtimes (Deno, Node.js, Cloudflare), and
 import { withSupabase } from 'npm:@supabase/server'
 
 export default {
-  fetch: withSupabase({ allow: 'user' }, async (_req, ctx) => {
+  fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
     const { data } = await ctx.supabase.from('orders').select('*')
     return Response.json(data)
   }),
 }
 ```
 
-The migration mapping: `SUPABASE_ANON_KEY` with manual auth header → `allow: 'user'`, `SUPABASE_ANON_KEY` without auth → `allow: 'public'`. For `SUPABASE_SERVICE_ROLE_KEY`, it depends on intent: if the legacy code validates the incoming key to protect the endpoint (e.g., `req.headers.get('apikey') === serviceRoleKey`), use `allow: 'secret'`. If it only uses the key to create an admin client for elevated DB access, no specific auth mode is needed — `ctx.supabaseAdmin` is always available regardless of auth mode.
+The migration mapping: `SUPABASE_ANON_KEY` with manual auth header → `auth: 'user'`, `SUPABASE_ANON_KEY` without auth → `auth: 'public'`. For `SUPABASE_SERVICE_ROLE_KEY`, it depends on intent: if the legacy code validates the incoming key to protect the endpoint (e.g., `req.headers.get('apikey') === serviceRoleKey`), use `auth: 'secret'`. If it only uses the key to create an admin client for elevated DB access, no specific auth mode is needed — `ctx.supabaseAdmin` is always available regardless of auth mode.
 
 ## Documentation
 

--- a/src/adapters/h3/middleware.test.ts
+++ b/src/adapters/h3/middleware.test.ts
@@ -13,7 +13,7 @@ describe('h3 supabase middleware', () => {
 
   it('sets supabase context on successful auth', async () => {
     const app = new H3()
-    app.use(withSupabase({ allow: 'always', env }))
+    app.use(withSupabase({ auth: 'always', env }))
     app.get('/', (event) => {
       const ctx = event.context.supabaseContext
       return {
@@ -33,7 +33,7 @@ describe('h3 supabase middleware', () => {
 
   it('throws HTTPError on auth failure', async () => {
     const app = new H3()
-    app.use(withSupabase({ allow: 'user', env }))
+    app.use(withSupabase({ auth: 'user', env }))
     app.get('/', () => ({ ok: true }))
 
     const res = await app.request('/')
@@ -55,7 +55,7 @@ describe('h3 supabase middleware', () => {
         )
       }),
     )
-    app.use(withSupabase({ allow: 'user', env }))
+    app.use(withSupabase({ auth: 'user', env }))
     app.get('/', () => ({ ok: true }))
 
     const res = await app.request('/')
@@ -69,9 +69,9 @@ describe('h3 supabase middleware', () => {
     const app = new H3()
 
     // First middleware sets context with 'always' auth
-    app.use(withSupabase({ allow: 'always', env }))
+    app.use(withSupabase({ auth: 'always', env }))
     // Second middleware would require 'secret' — but should skip
-    app.use(withSupabase({ allow: 'secret', env }))
+    app.use(withSupabase({ auth: 'secret', env }))
 
     app.get('/', (event) => {
       const ctx = event.context.supabaseContext
@@ -88,7 +88,7 @@ describe('h3 supabase middleware', () => {
 
   it('does not add CORS headers', async () => {
     const app = new H3()
-    app.use(withSupabase({ allow: 'always', env }))
+    app.use(withSupabase({ auth: 'always', env }))
     app.get('/', () => ({ ok: true }))
 
     const res = await app.request('/')

--- a/src/adapters/h3/middleware.ts
+++ b/src/adapters/h3/middleware.ts
@@ -19,7 +19,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * import { withSupabase } from '@supabase/server/adapters/h3'
  *
  * const app = new H3()
- * app.use(withSupabase({ allow: 'user' }))
+ * app.use(withSupabase({ auth: 'user' }))
  *
  * app.get('/games', async (event) => {
  *   const { supabase } = event.context.supabaseContext
@@ -35,7 +35,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * import { withSupabase } from '@supabase/server/adapters/h3'
  *
  * export default defineHandler({
- *   middleware: [withSupabase({ allow: 'user' })],
+ *   middleware: [withSupabase({ auth: 'user' })],
  *   handler: async (event) => {
  *     const { supabase } = event.context.supabaseContext
  *     return supabase.from('favorite_games').select()

--- a/src/adapters/hono/middleware.test.ts
+++ b/src/adapters/hono/middleware.test.ts
@@ -16,7 +16,7 @@ describe('hono supabase middleware', () => {
 
   it('sets supabase context on successful auth', async () => {
     const app = new Hono<Env>()
-    app.use('*', withSupabase({ allow: 'always', env }))
+    app.use('*', withSupabase({ auth: 'always', env }))
     app.get('/', (c) => {
       const ctx = c.get('supabaseContext')
       return c.json({
@@ -36,7 +36,7 @@ describe('hono supabase middleware', () => {
 
   it('throws HTTPException on auth failure', async () => {
     const app = new Hono()
-    app.use('*', withSupabase({ allow: 'user', env }))
+    app.use('*', withSupabase({ auth: 'user', env }))
     app.get('/', (c) => c.json({ ok: true }))
 
     const res = await app.request('/')
@@ -47,7 +47,7 @@ describe('hono supabase middleware', () => {
 
   it('exposes AuthError via cause in app.onError', async () => {
     const app = new Hono()
-    app.use('*', withSupabase({ allow: 'user', env }))
+    app.use('*', withSupabase({ auth: 'user', env }))
     app.get('/', (c) => c.json({ ok: true }))
     app.onError((err, c) => {
       const cause = (err as Error).cause as
@@ -70,9 +70,9 @@ describe('hono supabase middleware', () => {
     const app = new Hono<Env>()
 
     // First middleware sets context with 'always' auth
-    app.use('*', withSupabase({ allow: 'always', env }))
+    app.use('*', withSupabase({ auth: 'always', env }))
     // Second middleware would require 'secret' — but should skip
-    app.use('*', withSupabase({ allow: 'secret', env }))
+    app.use('*', withSupabase({ auth: 'secret', env }))
 
     app.get('/', (c) => {
       const ctx = c.get('supabaseContext')
@@ -89,7 +89,7 @@ describe('hono supabase middleware', () => {
 
   it('does not add CORS headers', async () => {
     const app = new Hono()
-    app.use('*', withSupabase({ allow: 'always', env }))
+    app.use('*', withSupabase({ auth: 'always', env }))
     app.get('/', (c) => c.json({ ok: true }))
 
     const res = await app.request('/')

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -20,7 +20,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * import { withSupabase } from '@supabase/server/adapters/hono'
  *
  * const app = new Hono()
- * app.use('*', withSupabase({ allow: 'user' }))
+ * app.use('*', withSupabase({ auth: 'user' }))
  *
  * app.get('/profile', async (c) => {
  *   const { supabase } = c.var.supabaseContext
@@ -39,7 +39,7 @@ export function withSupabase(
   }>(async (c, next) => {
     // Skip if a previous middleware already set the context.
     // This allows route-level overrides: a route can use withSupabase({ allow: 'secret' })
-    // while the app-wide middleware uses withSupabase({ allow: 'user' }), without the
+    // while the app-wide middleware uses withSupabase({ auth: 'user' }), without the
     // app-wide one overwriting the stricter context already established.
     if (c.var.supabaseContext) {
       await next()

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -18,7 +18,7 @@ import { resolveEnv } from './resolve-env.js'
  *
  * @example
  * ```ts
- * const { data: auth } = await verifyAuth(request, { allow: 'user' })
+ * const { data: auth } = await verifyAuth(request, { auth: 'user' })
  * const supabase = createContextClient({
  *   auth: { token: auth.token, keyName: auth.keyName },
  * })

--- a/src/core/utils/deprecation.ts
+++ b/src/core/utils/deprecation.ts
@@ -1,0 +1,47 @@
+import type { AuthModeWithKey } from '../../types.js'
+
+let allowDeprecationWarned = false
+
+/**
+ * Emits a one-time deprecation warning when the legacy `allow` option is used
+ * instead of `auth`. The warning fires at most once per process to avoid
+ * spamming logs in long-running servers.
+ *
+ * @internal
+ */
+export function warnAllowDeprecated(): void {
+  if (allowDeprecationWarned) return
+  allowDeprecationWarned = true
+  console.warn(
+    '[@supabase/server] The `allow` option is deprecated and will be removed in a future major release. Use `auth` instead — e.g. `{ auth: "user" }` instead of `{ allow: "user" }`.',
+  )
+}
+
+/**
+ * Resolves the auth mode from `auth` (preferred) or `allow` (deprecated),
+ * falling back to `"user"` when neither is provided. Emits a one-time
+ * deprecation warning when `allow` is used without `auth`.
+ *
+ * @internal
+ */
+export function resolveAuthOption(options: {
+  auth?: AuthModeWithKey | AuthModeWithKey[]
+  allow?: AuthModeWithKey | AuthModeWithKey[]
+}): AuthModeWithKey | AuthModeWithKey[] {
+  if (options.auth !== undefined) return options.auth
+  if (options.allow !== undefined) {
+    warnAllowDeprecated()
+    return options.allow
+  }
+  return 'user'
+}
+
+/**
+ * Test-only helper to reset the one-shot deprecation warning latch so each
+ * test can independently observe the warning.
+ *
+ * @internal
+ */
+export function _resetAllowDeprecationWarned(): void {
+  allowDeprecationWarned = false
+}

--- a/src/core/verify-auth.test.ts
+++ b/src/core/verify-auth.test.ts
@@ -14,7 +14,7 @@ describe('verifyAuth', () => {
     const req = new Request('http://localhost', {
       headers: { apikey: 'sb_publishable_xyz' },
     })
-    const result = await verifyAuth(req, { allow: 'public', env })
+    const result = await verifyAuth(req, { auth: 'public', env })
     expect(result.error).toBeNull()
     expect(result.data!.authType).toBe('public')
   })
@@ -23,7 +23,7 @@ describe('verifyAuth', () => {
     const req = new Request('http://localhost', {
       headers: { apikey: 'wrong' },
     })
-    const result = await verifyAuth(req, { allow: 'public', env })
+    const result = await verifyAuth(req, { auth: 'public', env })
     expect(result.error).not.toBeNull()
   })
 })

--- a/src/core/verify-auth.ts
+++ b/src/core/verify-auth.ts
@@ -1,5 +1,5 @@
 import type { AuthError } from '../errors.js'
-import type { AllowWithKey, AuthResult, SupabaseEnv } from '../types.js'
+import type { AuthModeWithKey, AuthResult, SupabaseEnv } from '../types.js'
 import { extractCredentials } from './extract-credentials.js'
 import { verifyCredentials } from './verify-credentials.js'
 
@@ -10,9 +10,18 @@ interface VerifyAuthOptions {
   /**
    * Auth mode(s) to try. Modes are attempted in order — the first match wins.
    *
-   * @see {@link AllowWithKey} for the full syntax including named keys.
+   * @see {@link AuthModeWithKey} for the full syntax including named keys.
+   *
+   * @defaultValue `"user"`
    */
-  allow: AllowWithKey | AllowWithKey[]
+  auth?: AuthModeWithKey | AuthModeWithKey[]
+
+  /**
+   * @deprecated Use {@link VerifyAuthOptions.auth} instead. Kept for backward
+   * compatibility; will be removed in a future major release. When both are
+   * provided, `auth` wins.
+   */
+  allow?: AuthModeWithKey | AuthModeWithKey[]
 
   /** Optional environment overrides (passed through to {@link resolveEnv}). */
   env?: Partial<SupabaseEnv>
@@ -37,7 +46,7 @@ interface VerifyAuthOptions {
  * import { verifyAuth } from '@supabase/server/core'
  *
  * const { data: auth, error } = await verifyAuth(request, {
- *   allow: 'user',
+ *   auth: 'user',
  * })
  *
  * if (error) {

--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -1,8 +1,9 @@
 import { exportJWK, generateKeyPair, SignJWT } from 'jose'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Credentials, JsonWebKeySet, SupabaseEnv } from '../types.js'
 import { verifyCredentials } from './verify-credentials.js'
+import { _resetAllowDeprecationWarned } from './utils/deprecation.js'
 import { InvalidCredentialsError } from '../errors.js'
 
 function makeEnv(overrides?: Partial<SupabaseEnv>): Partial<SupabaseEnv> {
@@ -20,7 +21,7 @@ describe('verifyCredentials', () => {
     it('succeeds with no credentials and keyName is null', async () => {
       const creds: Credentials = { token: null, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: 'always',
+        auth: 'always',
         env: makeEnv(),
       })
       expect(result.error).toBeNull()
@@ -36,7 +37,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_xyz',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public',
+        auth: 'public',
         env: makeEnv(),
       })
       expect(result.error).toBeNull()
@@ -47,7 +48,7 @@ describe('verifyCredentials', () => {
     it('fails with invalid key', async () => {
       const creds: Credentials = { token: null, apikey: 'wrong_key' }
       const result = await verifyCredentials(creds, {
-        allow: 'public',
+        auth: 'public',
         env: makeEnv(),
       })
       expect(result.error).not.toBeNull()
@@ -63,7 +64,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_publishable_web' }
       const result = await verifyCredentials(creds, {
-        allow: 'public',
+        auth: 'public',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -79,7 +80,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_publishable_web' }
       const result = await verifyCredentials(creds, {
-        allow: 'public:web',
+        auth: 'public:web',
         env,
       })
       expect(result.error).toBeNull()
@@ -98,7 +99,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_mobile',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public:web',
+        auth: 'public:web',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -114,7 +115,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_publishable_web' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret:web',
+        auth: 'secret:web',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -133,7 +134,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_mobile',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public:*',
+        auth: 'public:*',
         env,
       })
       expect(result.error).toBeNull()
@@ -153,7 +154,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_mobile',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public:*',
+        auth: 'public:*',
         env,
       })
       expect(result.error).toBeNull()
@@ -165,7 +166,7 @@ describe('verifyCredentials', () => {
     it('succeeds with valid secret key and returns default keyName', async () => {
       const creds: Credentials = { token: null, apikey: 'sb_secret_xyz' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret',
+        auth: 'secret',
         env: makeEnv(),
       })
       expect(result.error).toBeNull()
@@ -176,7 +177,7 @@ describe('verifyCredentials', () => {
     it('fails with invalid secret key', async () => {
       const creds: Credentials = { token: null, apikey: 'wrong_secret' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret',
+        auth: 'secret',
         env: makeEnv(),
       })
       expect(result.error).not.toBeNull()
@@ -189,7 +190,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_secret_web' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret',
+        auth: 'secret',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -202,7 +203,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_secret_web' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret:web',
+        auth: 'secret:web',
         env,
       })
       expect(result.error).toBeNull()
@@ -215,7 +216,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_secret_mobile' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret:web',
+        auth: 'secret:web',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -228,7 +229,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_secret_web' }
       const result = await verifyCredentials(creds, {
-        allow: 'public:web',
+        auth: 'public:web',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -241,7 +242,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_secret_mobile' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret:*',
+        auth: 'secret:*',
         env,
       })
       expect(result.error).toBeNull()
@@ -258,7 +259,7 @@ describe('verifyCredentials', () => {
       })
       const creds: Credentials = { token: null, apikey: 'sb_secret_mobile' }
       const result = await verifyCredentials(creds, {
-        allow: 'secret:*',
+        auth: 'secret:*',
         env,
       })
       expect(result.error).toBeNull()
@@ -291,7 +292,7 @@ describe('verifyCredentials', () => {
     it('succeeds with valid JWT', async () => {
       const creds: Credentials = { token: validToken, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: 'user',
+        auth: 'user',
         env: makeEnv({ jwks }),
       })
       expect(result.error).toBeNull()
@@ -306,7 +307,7 @@ describe('verifyCredentials', () => {
     it('fails with invalid JWT', async () => {
       const creds: Credentials = { token: 'invalid.jwt.token', apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: 'user',
+        auth: 'user',
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
@@ -316,7 +317,7 @@ describe('verifyCredentials', () => {
     it('fails with no token', async () => {
       const creds: Credentials = { token: null, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: 'user',
+        auth: 'user',
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
@@ -338,7 +339,7 @@ describe('verifyCredentials', () => {
 
       const creds: Credentials = { token: expiredToken, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: 'user',
+        auth: 'user',
         env: makeEnv({ jwks: expiredJwks }),
       })
       expect(result.error).not.toBeNull()
@@ -346,14 +347,14 @@ describe('verifyCredentials', () => {
     })
   })
 
-  describe('parseAllowMode edge cases', () => {
+  describe('parseAuthMode edge cases', () => {
     it('treats trailing colon as bare mode (default key)', async () => {
       const creds: Credentials = {
         token: null,
         apikey: 'sb_publishable_xyz',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public:' as 'public',
+        auth: 'public:' as 'public',
         env: makeEnv(),
       })
       expect(result.error).toBeNull()
@@ -369,7 +370,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_colon',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public:key:extra' as 'public',
+        auth: 'public:key:extra' as 'public',
         env,
       })
       expect(result.error).toBeNull()
@@ -383,7 +384,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_xyz',
       }
       const result = await verifyCredentials(creds, {
-        allow: 'public:*' as 'public',
+        auth: 'public:*' as 'public',
         env,
       })
       expect(result.error).not.toBeNull()
@@ -391,14 +392,14 @@ describe('verifyCredentials', () => {
     })
   })
 
-  describe('array allow (first match wins)', () => {
+  describe('array auth (first match wins)', () => {
     it('matches second mode when first fails and returns its keyName', async () => {
       const creds: Credentials = {
         token: null,
         apikey: 'sb_publishable_xyz',
       }
       const result = await verifyCredentials(creds, {
-        allow: ['secret', 'public'],
+        auth: ['secret', 'public'],
         env: makeEnv(),
       })
       expect(result.error).toBeNull()
@@ -409,7 +410,7 @@ describe('verifyCredentials', () => {
     it('matches first mode when it succeeds', async () => {
       const creds: Credentials = { token: null, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: ['always', 'public'],
+        auth: ['always', 'public'],
         env: makeEnv(),
       })
       expect(result.error).toBeNull()
@@ -431,7 +432,7 @@ describe('verifyCredentials', () => {
     it('rejects invalid JWT instead of falling through to always mode', async () => {
       const creds: Credentials = { token: 'garbage.jwt.token', apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: ['user', 'always'],
+        auth: ['user', 'always'],
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
@@ -453,7 +454,7 @@ describe('verifyCredentials', () => {
 
       const creds: Credentials = { token: expiredToken, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: ['user', 'always'],
+        auth: ['user', 'always'],
         env: makeEnv({ jwks: expiredJwks }),
       })
       expect(result.error).not.toBeNull()
@@ -463,7 +464,7 @@ describe('verifyCredentials', () => {
     it('falls through to always when no token is present', async () => {
       const creds: Credentials = { token: null, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: ['user', 'always'],
+        auth: ['user', 'always'],
         env: makeEnv({ jwks }),
       })
       expect(result.error).toBeNull()
@@ -476,7 +477,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_publishable_xyz',
       }
       const result = await verifyCredentials(creds, {
-        allow: ['user', 'public'],
+        auth: ['user', 'public'],
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
@@ -489,7 +490,7 @@ describe('verifyCredentials', () => {
         apikey: 'sb_secret_xyz',
       }
       const result = await verifyCredentials(creds, {
-        allow: ['user', 'secret'],
+        auth: ['user', 'secret'],
         env: makeEnv({ jwks }),
       })
       expect(result.error).not.toBeNull()
@@ -511,9 +512,83 @@ describe('verifyCredentials', () => {
 
       const creds: Credentials = { token: noSubToken, apikey: null }
       const result = await verifyCredentials(creds, {
-        allow: 'user',
+        auth: 'user',
         env: makeEnv({ jwks: noSubJwks }),
       })
+      expect(result.error).not.toBeNull()
+      expect(result.error!.code).toBe(InvalidCredentialsError)
+    })
+  })
+
+  describe('allow → auth deprecation', () => {
+    beforeEach(() => {
+      _resetAllowDeprecationWarned()
+    })
+
+    it('still accepts the deprecated `allow` option', async () => {
+      const creds: Credentials = { token: null, apikey: null }
+      const result = await verifyCredentials(creds, {
+        allow: 'always',
+        env: makeEnv(),
+      })
+      expect(result.error).toBeNull()
+      expect(result.data!.authType).toBe('always')
+    })
+
+    it('emits a deprecation warning when `allow` is used', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const creds: Credentials = { token: null, apikey: null }
+      await verifyCredentials(creds, {
+        allow: 'always',
+        env: makeEnv(),
+      })
+      expect(warn).toHaveBeenCalledTimes(1)
+      const message = warn.mock.calls[0]![0] as string
+      expect(message).toContain('@supabase/server')
+      expect(message).toContain('`allow`')
+      expect(message).toContain('`auth`')
+      warn.mockRestore()
+    })
+
+    it('only warns once across multiple calls', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const creds: Credentials = { token: null, apikey: null }
+      await verifyCredentials(creds, { allow: 'always', env: makeEnv() })
+      await verifyCredentials(creds, { allow: 'always', env: makeEnv() })
+      await verifyCredentials(creds, { allow: 'always', env: makeEnv() })
+      expect(warn).toHaveBeenCalledTimes(1)
+      warn.mockRestore()
+    })
+
+    it('does not warn when `auth` is used', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const creds: Credentials = { token: null, apikey: null }
+      await verifyCredentials(creds, { auth: 'always', env: makeEnv() })
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('prefers `auth` over `allow` when both are provided', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const creds: Credentials = { token: null, apikey: 'sb_secret_xyz' }
+      const result = await verifyCredentials(creds, {
+        // `auth` should win and the secret key should match.
+        auth: 'secret',
+        // `allow` would have rejected the secret key (public mode).
+        allow: 'public',
+        env: makeEnv(),
+      })
+      expect(result.error).toBeNull()
+      expect(result.data!.authType).toBe('secret')
+      // No warning since `auth` is the operative option.
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('defaults to `user` when neither `auth` nor `allow` is provided', async () => {
+      const creds: Credentials = { token: null, apikey: null }
+      const result = await verifyCredentials(creds, { env: makeEnv() })
+      // No token, no apikey, default mode is `user` → fails with invalid credentials.
       expect(result.error).not.toBeNull()
       expect(result.error!.code).toBe(InvalidCredentialsError)
     })

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -2,14 +2,15 @@ import { createLocalJWKSet, jwtVerify } from 'jose'
 
 import { AuthError, Errors, InvalidCredentialsError } from '../errors.js'
 import type {
-  Allow,
-  AllowWithKey,
+  AuthMode,
+  AuthModeWithKey,
   AuthResult,
   Credentials,
   JWTClaims,
   SupabaseEnv,
   UserClaims,
 } from '../types.js'
+import { resolveAuthOption } from './utils/deprecation.js'
 import { timingSafeEqual } from './utils/timing-safe-equal.js'
 import { resolveEnv } from './resolve-env.js'
 
@@ -20,28 +21,37 @@ interface VerifyCredentialsOptions {
   /**
    * Auth mode(s) to try. Modes are attempted in order — the first match wins.
    *
-   * @see {@link AllowWithKey} for the full syntax including named keys.
+   * @see {@link AuthModeWithKey} for the full syntax including named keys.
+   *
+   * @defaultValue `"user"`
    */
-  allow: AllowWithKey | AllowWithKey[]
+  auth?: AuthModeWithKey | AuthModeWithKey[]
+
+  /**
+   * @deprecated Use {@link VerifyCredentialsOptions.auth} instead. Kept for
+   * backward compatibility; will be removed in a future major release. When
+   * both are provided, `auth` wins.
+   */
+  allow?: AuthModeWithKey | AuthModeWithKey[]
 
   /** Optional environment overrides (passed through to {@link resolveEnv}). */
   env?: Partial<SupabaseEnv>
 }
 
 /**
- * Parses an {@link AllowWithKey} string into its base mode and optional key name.
+ * Parses an {@link AuthModeWithKey} string into its base mode and optional key name.
  *
  * @example
  * ```
- * parseAllowMode('user')         → { base: 'user',   keyName: null }
- * parseAllowMode('public:web')   → { base: 'public', keyName: 'web' }
- * parseAllowMode('secret:*')     → { base: 'secret', keyName: '*' }
+ * parseAuthMode('user')         → { base: 'user',   keyName: null }
+ * parseAuthMode('public:web')   → { base: 'public', keyName: 'web' }
+ * parseAuthMode('secret:*')     → { base: 'secret', keyName: '*' }
  * ```
  *
  * @internal
  */
-function parseAllowMode(mode: AllowWithKey): {
-  base: Allow
+function parseAuthMode(mode: AuthModeWithKey): {
+  base: AuthMode
   keyName: string | null
 } {
   if (
@@ -53,7 +63,7 @@ function parseAllowMode(mode: AllowWithKey): {
     return { base: mode, keyName: null }
   }
   const colonIndex = mode.indexOf(':')
-  const base = mode.slice(0, colonIndex) as Allow
+  const base = mode.slice(0, colonIndex) as AuthMode
   const keyName = mode.slice(colonIndex + 1)
   if (!keyName) return { base, keyName: null }
   return { base, keyName }
@@ -86,11 +96,11 @@ const INVALID = Symbol('invalid')
  * @internal
  */
 async function tryMode(
-  mode: AllowWithKey,
+  mode: AuthModeWithKey,
   credentials: Credentials,
   env: SupabaseEnv,
 ): Promise<AuthResult | typeof INVALID | null> {
-  const { base, keyName } = parseAllowMode(mode)
+  const { base, keyName } = parseAuthMode(mode)
 
   switch (base) {
     case 'always':
@@ -210,7 +220,7 @@ async function tryMode(
  * ```ts
  * const credentials = extractCredentials(request)
  * const { data: auth, error } = await verifyCredentials(credentials, {
- *   allow: ['user', 'public'],
+ *   auth: ['user', 'public'],
  * })
  * if (error) {
  *   return Response.json({ message: error.message }, { status: error.status })
@@ -231,7 +241,8 @@ export async function verifyCredentials(
     }
   }
 
-  const modes = Array.isArray(options.allow) ? options.allow : [options.allow]
+  const resolved = resolveAuthOption(options)
+  const modes = Array.isArray(resolved) ? resolved : [resolved]
 
   for (const mode of modes) {
     const result = await tryMode(mode, credentials, env)

--- a/src/create-supabase-context.test.ts
+++ b/src/create-supabase-context.test.ts
@@ -17,7 +17,7 @@ describe('createSupabaseContext', () => {
   it('returns context with clients on successful auth', async () => {
     const req = new Request('http://localhost')
     const result = await createSupabaseContext(req, {
-      allow: 'always',
+      auth: 'always',
       env: baseEnv,
     })
 
@@ -32,7 +32,7 @@ describe('createSupabaseContext', () => {
   it('returns user and claims as null for non-user auth', async () => {
     const req = new Request('http://localhost')
     const result = await createSupabaseContext(req, {
-      allow: 'always',
+      auth: 'always',
       env: baseEnv,
     })
 
@@ -43,7 +43,7 @@ describe('createSupabaseContext', () => {
   it('returns error when auth fails', async () => {
     const req = new Request('http://localhost')
     const result = await createSupabaseContext(req, {
-      allow: 'user',
+      auth: 'user',
       env: baseEnv,
     })
 
@@ -53,7 +53,7 @@ describe('createSupabaseContext', () => {
     expect(result.error!.code).toBeDefined()
   })
 
-  it('defaults to allow: user when no options provided', async () => {
+  it('defaults to auth: user when no options provided', async () => {
     const req = new Request('http://localhost')
     const result = await createSupabaseContext(req, { env: baseEnv })
 
@@ -67,7 +67,7 @@ describe('createSupabaseContext', () => {
       headers: { apikey: 'sb_publishable_xyz' },
     })
     const result = await createSupabaseContext(req, {
-      allow: 'public',
+      auth: 'public',
       env: baseEnv,
     })
 
@@ -83,7 +83,7 @@ describe('createSupabaseContext', () => {
       headers: { apikey: 'sb_publishable_web' },
     })
     const result = await createSupabaseContext(req, {
-      allow: 'public:web',
+      auth: 'public:web',
       env: {
         ...baseEnv,
         publishableKeys: {
@@ -104,7 +104,7 @@ describe('createSupabaseContext', () => {
       headers: { apikey: 'sb_secret_xyz' },
     })
     const result = await createSupabaseContext(req, {
-      allow: 'secret',
+      auth: 'secret',
       env: baseEnv,
     })
 
@@ -118,7 +118,7 @@ describe('createSupabaseContext', () => {
       headers: { apikey: 'sb_secret_web' },
     })
     const result = await createSupabaseContext(req, {
-      allow: 'secret:web',
+      auth: 'secret:web',
       env: {
         ...baseEnv,
         secretKeys: {
@@ -139,7 +139,7 @@ describe('createSupabaseContext', () => {
       headers: { apikey: 'wrong_key' },
     })
     const result = await createSupabaseContext(req, {
-      allow: 'secret',
+      auth: 'secret',
       env: baseEnv,
     })
 
@@ -150,7 +150,7 @@ describe('createSupabaseContext', () => {
   it('returns error when client creation fails due to missing keys', async () => {
     const req = new Request('http://localhost')
     const result = await createSupabaseContext(req, {
-      allow: 'always',
+      auth: 'always',
       env: {
         url: 'https://test.supabase.co',
         publishableKeys: {},
@@ -171,7 +171,7 @@ describe('createSupabaseContext', () => {
   it('passes supabaseOptions through to clients', async () => {
     const req = new Request('http://localhost')
     const result = await createSupabaseContext(req, {
-      allow: 'always',
+      auth: 'always',
       env: baseEnv,
       supabaseOptions: { db: { schema: 'api' } },
     })

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -22,7 +22,7 @@ import { verifyAuth } from './core/verify-auth.js'
  *
  * @example
  * ```ts
- * const { data: ctx, error } = await createSupabaseContext(request, { allow: 'user' })
+ * const { data: ctx, error } = await createSupabaseContext(request, { auth: 'user' })
  * if (error) {
  *   return Response.json({ message: error.message }, { status: error.status })
  * }
@@ -36,10 +36,9 @@ export async function createSupabaseContext<Database = unknown>(
   | { data: SupabaseContext<Database>; error: null }
   | { data: null; error: AuthError }
 > {
-  const allow = options?.allow ?? 'user'
-
   const { data: auth, error } = await verifyAuth(request, {
-    allow,
+    auth: options?.auth,
+    allow: options?.allow,
     env: options?.env,
   })
   if (error) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -95,7 +95,7 @@ const EnvErrorMap = {
  * ```ts
  * import { AuthError, createSupabaseContext } from '@supabase/server'
  *
- * const { data: ctx, error } = await createSupabaseContext(request, { allow: 'user' })
+ * const { data: ctx, error } = await createSupabaseContext(request, { auth: 'user' })
  * if (error) {
  *   // error is an AuthError
  *   return Response.json(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export { createSupabaseContext } from './create-supabase-context.js'
 export type {
   Allow,
   AllowWithKey,
+  AuthMode,
+  AuthModeWithKey,
   AuthResult,
   ClientAuth,
   CreateAdminClientOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,16 +14,21 @@ import type {
  * @example
  * ```ts
  * // Single mode
- * withSupabase({ allow: 'user' }, handler)
+ * withSupabase({ auth: 'user' }, handler)
  *
  * // Multiple modes — the first match wins.
  * // A mode is tried only when its credential is present; a JWT that is
  * // present but fails verification rejects immediately rather than falling
  * // through to the next mode.
- * withSupabase({ allow: ['user', 'public'] }, handler)
+ * withSupabase({ auth: ['user', 'public'] }, handler)
  * ```
  */
-export type Allow = 'always' | 'public' | 'secret' | 'user'
+export type AuthMode = 'always' | 'public' | 'secret' | 'user'
+
+/**
+ * @deprecated Use {@link AuthMode} instead. Will be removed in a future major release.
+ */
+export type Allow = AuthMode
 
 /**
  * Extended auth mode that supports targeting a specific named key.
@@ -35,16 +40,21 @@ export type Allow = 'always' | 'public' | 'secret' | 'user'
  * @example
  * ```ts
  * // Accept only the "mobile" publishable key
- * withSupabase({ allow: 'public:mobile' }, handler)
+ * withSupabase({ auth: 'public:mobile' }, handler)
  *
  * // Accept any secret key
- * withSupabase({ allow: 'secret:*' }, handler)
+ * withSupabase({ auth: 'secret:*' }, handler)
  *
  * // Mix named keys with other modes
- * withSupabase({ allow: ['user', 'public:web_app'] }, handler)
+ * withSupabase({ auth: ['user', 'public:web_app'] }, handler)
  * ```
  */
-export type AllowWithKey = Allow | `public:${string}` | `secret:${string}`
+export type AuthModeWithKey = AuthMode | `public:${string}` | `secret:${string}`
+
+/**
+ * @deprecated Use {@link AuthModeWithKey} instead. Will be removed in a future major release.
+ */
+export type AllowWithKey = AuthModeWithKey
 
 /**
  * Resolved Supabase environment configuration.
@@ -115,7 +125,7 @@ export interface Credentials {
  */
 export interface AuthResult {
   /** The auth mode that was successfully matched. */
-  authType: Allow
+  authType: AuthMode
 
   /** The verified JWT, or `null` for non-user auth modes. */
   token: string | null
@@ -201,16 +211,16 @@ export interface UserClaims {
  * @example
  * ```ts
  * // Require authenticated users, auto-CORS enabled (default)
- * const config: WithSupabaseConfig = { allow: 'user' }
+ * const config: WithSupabaseConfig = { auth: 'user' }
  *
  * // Accept users or service-to-service calls, custom CORS headers
  * const config: WithSupabaseConfig = {
- *   allow: ['user', 'secret'],
+ *   auth: ['user', 'secret'],
  *   cors: { 'Access-Control-Allow-Origin': 'https://myapp.com' },
  * }
  *
  * // No auth required, CORS disabled
- * const config: WithSupabaseConfig = { allow: 'always', cors: false }
+ * const config: WithSupabaseConfig = { auth: 'always', cors: false }
  * ```
  */
 export interface WithSupabaseConfig {
@@ -221,7 +231,14 @@ export interface WithSupabaseConfig {
    *
    * @defaultValue `"user"`
    */
-  allow?: AllowWithKey | AllowWithKey[]
+  auth?: AuthModeWithKey | AuthModeWithKey[]
+
+  /**
+   * @deprecated Use {@link WithSupabaseConfig.auth} instead. The `allow` option
+   * is kept for backward compatibility and will be removed in a future major release.
+   * When both `auth` and `allow` are provided, `auth` takes precedence.
+   */
+  allow?: AuthModeWithKey | AuthModeWithKey[]
 
   /**
    * Override auto-detected environment variables. Useful for testing
@@ -252,7 +269,7 @@ export interface WithSupabaseConfig {
    * @example
    * ```ts
    * withSupabase({
-   *   allow: 'user',
+   *   auth: 'user',
    *   supabaseOptions: { db: { schema: 'api' } },
    * }, handler)
    * ```
@@ -317,7 +334,7 @@ export interface SupabaseContext<Database = unknown> {
   claims: JWTClaims | null
 
   /** The auth mode that was used for this request. */
-  authType: Allow
+  authType: AuthMode
 
   /** The auth key name of the API key that was used for this request. */
   authKeyName?: string | null

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { _resetAllowDeprecationWarned } from './core/utils/deprecation.js'
 import { withSupabase } from './with-supabase.js'
 
 const baseEnv = {
@@ -11,7 +12,7 @@ const baseEnv = {
 
 describe('withSupabase', () => {
   it('handles OPTIONS preflight with CORS', async () => {
-    const handler = withSupabase({ allow: 'always', env: baseEnv }, async () =>
+    const handler = withSupabase({ auth: 'always', env: baseEnv }, async () =>
       Response.json({ ok: true }),
     )
 
@@ -23,7 +24,7 @@ describe('withSupabase', () => {
 
   it('skips OPTIONS handling when cors is false', async () => {
     const handler = withSupabase(
-      { allow: 'always', env: baseEnv, cors: false },
+      { auth: 'always', env: baseEnv, cors: false },
       async () => Response.json({ ok: true }),
     )
 
@@ -35,7 +36,7 @@ describe('withSupabase', () => {
 
   it('calls handler with context on successful auth', async () => {
     const handler = withSupabase(
-      { allow: 'always', env: baseEnv },
+      { auth: 'always', env: baseEnv },
       async (_req, ctx) => {
         return Response.json({
           authType: ctx.authType,
@@ -54,7 +55,7 @@ describe('withSupabase', () => {
   })
 
   it('returns error response on auth failure', async () => {
-    const handler = withSupabase({ allow: 'user', env: baseEnv }, async () =>
+    const handler = withSupabase({ auth: 'user', env: baseEnv }, async () =>
       Response.json({ ok: true }),
     )
 
@@ -67,7 +68,7 @@ describe('withSupabase', () => {
   })
 
   it('adds CORS headers to success response', async () => {
-    const handler = withSupabase({ allow: 'always', env: baseEnv }, async () =>
+    const handler = withSupabase({ auth: 'always', env: baseEnv }, async () =>
       Response.json({ ok: true }),
     )
 
@@ -77,7 +78,7 @@ describe('withSupabase', () => {
   })
 
   it('adds CORS headers to error response', async () => {
-    const handler = withSupabase({ allow: 'user', env: baseEnv }, async () =>
+    const handler = withSupabase({ auth: 'user', env: baseEnv }, async () =>
       Response.json({ ok: true }),
     )
 
@@ -88,12 +89,45 @@ describe('withSupabase', () => {
 
   it('does not add CORS headers when cors is false', async () => {
     const handler = withSupabase(
-      { allow: 'always', env: baseEnv, cors: false },
+      { auth: 'always', env: baseEnv, cors: false },
       async () => Response.json({ ok: true }),
     )
 
     const req = new Request('http://localhost')
     const res = await handler(req)
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  describe('allow → auth deprecation', () => {
+    beforeEach(() => {
+      _resetAllowDeprecationWarned()
+    })
+
+    it('still works with the deprecated `allow` option', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const handler = withSupabase(
+        { allow: 'always', env: baseEnv },
+        async (_req, ctx) => Response.json({ authType: ctx.authType }),
+      )
+
+      const req = new Request('http://localhost')
+      const res = await handler(req)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.authType).toBe('always')
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('does not warn when `auth` is used', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const handler = withSupabase({ auth: 'always', env: baseEnv }, async () =>
+        Response.json({ ok: true }),
+      )
+      const req = new Request('http://localhost')
+      await handler(req)
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
   })
 })

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -18,7 +18,7 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
  * import { withSupabase } from '@supabase/server'
  *
  * export default {
- *   fetch: withSupabase({ allow: 'user' }, async (req, ctx) => {
+ *   fetch: withSupabase({ auth: 'user' }, async (req, ctx) => {
  *     const { data } = await ctx.supabase.rpc('get_my_profile')
  *     return Response.json(data)
  *   }),


### PR DESCRIPTION
## Summary

- Renames the `allow` config option to `auth` across `withSupabase`, `createSupabaseContext`, `verifyAuth`, and `verifyCredentials` to match Supabase CLI terminology — `auth: 'user'` reads more naturally than `allow: 'user'`.
- The legacy `allow` key still works for backward compatibility; using it emits a one-time `console.warn` per process. When both `auth` and `allow` are provided, `auth` wins. `allow` will be removed in a future major release.
- Adds new exported types `AuthMode` and `AuthModeWithKey`. `Allow` and `AllowWithKey` are kept as deprecated type aliases.
- Migration is a find-and-replace from `allow:` → `auth:` — the values are identical.

## Notes

- All call-sites in source, tests, README, `skills/supabase-server/SKILL.md`, and `docs/*.md` updated to use `auth:`.
- Added migration callouts at the top of `README.md`, `docs/auth-modes.md`, and `SKILL.md`.
- New `core/utils/deprecation.ts` centralizes the `auth` / `allow` resolution and the one-shot warn.
- New `allow → auth deprecation` test blocks in `verify-credentials.test.ts` and `with-supabase.test.ts` cover: `allow` still works, warning fires once, no warning when `auth` is used, `auth` precedence when both provided, default `'user'` when neither provided.