### PR TITLE
chore: drop pre-major release-please flags after v1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "initial-version": "0.1.0",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "extra-files": ["jsr.json"]
     }
   },


### PR DESCRIPTION
`bump-minor-pre-major` and `bump-patch-for-minor-pre-major` are no-ops on 1.x. `initial-version` is also obsolete now that we're past it. Future releases follow standard SemVer from conventional commits.