### PR TITLE
feat(env): add support for JWKS discovery endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,13 @@ export default {
 
 Automatically available in Supabase Edge Functions:
 
-| Variable                    | Format                                                        | Description                                                                  |
-| --------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `SUPABASE_URL`              | `https://<ref>.supabase.co`                                   | Your project URL                                                             |
-| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_...","web":"sb_publishable_..."}` | Publishable API keys (named)                                                 |
-| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_...","web":"sb_secret_..."}`           | Secret API keys (named)                                                      |
-| `SUPABASE_JWKS`             | `{"keys":[...]}`, `[...]`, or `https://...`                   | JSON Web Key Set for JWT verification (inline JSON or remote `https://` URL) |
+| Variable                    | Format                                                        | Description                                               |
+| --------------------------- | ------------------------------------------------------------- | --------------------------------------------------------- |
+| `SUPABASE_URL`              | `https://<ref>.supabase.co`                                   | Your project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_...","web":"sb_publishable_..."}` | Publishable API keys (named)                              |
+| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_...","web":"sb_secret_..."}`           | Secret API keys (named)                                   |
+| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`                                   | Inline JSON Web Key Set for JWT verification              |
+| `SUPABASE_JWKS_URL`         | `https://...`                                                 | Remote JWKS endpoint (used when `SUPABASE_JWKS` is unset) |
 
 Also supported (for local dev, self-hosted, or other runtimes):
 

--- a/README.md
+++ b/README.md
@@ -400,12 +400,12 @@ export default {
 
 Automatically available in Supabase Edge Functions:
 
-| Variable                    | Format                                                        | Description                           |
-| --------------------------- | ------------------------------------------------------------- | ------------------------------------- |
-| `SUPABASE_URL`              | `https://<ref>.supabase.co`                                   | Your project URL                      |
-| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_...","web":"sb_publishable_..."}` | Publishable API keys (named)          |
-| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_...","web":"sb_secret_..."}`           | Secret API keys (named)               |
-| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`                                   | JSON Web Key Set for JWT verification |
+| Variable                    | Format                                                        | Description                                                                  |
+| --------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `SUPABASE_URL`              | `https://<ref>.supabase.co`                                   | Your project URL                                                             |
+| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_...","web":"sb_publishable_..."}` | Publishable API keys (named)                                                 |
+| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_...","web":"sb_secret_..."}`           | Secret API keys (named)                                                      |
+| `SUPABASE_JWKS`             | `{"keys":[...]}`, `[...]`, or `https://...`                   | JSON Web Key Set for JWT verification (inline JSON or remote `https://` URL) |
 
 Also supported (for local dev, self-hosted, or other runtimes):
 

--- a/README.md
+++ b/README.md
@@ -400,20 +400,20 @@ export default {
 
 Automatically available in Supabase Edge Functions:
 
-| Variable                    | Format                                                        | Description                                               |
-| --------------------------- | ------------------------------------------------------------- | --------------------------------------------------------- |
-| `SUPABASE_URL`              | `https://<ref>.supabase.co`                                   | Your project URL                                          |
-| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_...","web":"sb_publishable_..."}` | Publishable API keys (named)                              |
-| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_...","web":"sb_secret_..."}`           | Secret API keys (named)                                   |
-| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`                                   | Inline JSON Web Key Set for JWT verification              |
-| `SUPABASE_JWKS_URL`         | `https://...`                                                 | Remote JWKS endpoint (used when `SUPABASE_JWKS` is unset) |
+| Variable                    | Format                                                        | Description                                  |
+| --------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
+| `SUPABASE_URL`              | `https://<ref>.supabase.co`                                   | Your project URL                             |
+| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_...","web":"sb_publishable_..."}` | Publishable API keys (named)                 |
+| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_...","web":"sb_secret_..."}`           | Secret API keys (named)                      |
+| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`                                   | Inline JSON Web Key Set for JWT verification |
 
 Also supported (for local dev, self-hosted, or other runtimes):
 
-| Variable                   | Format               | Description            |
-| -------------------------- | -------------------- | ---------------------- |
-| `SUPABASE_PUBLISHABLE_KEY` | `sb_publishable_...` | Single publishable key |
-| `SUPABASE_SECRET_KEY`      | `sb_secret_...`      | Single secret key      |
+| Variable                   | Format               | Description                                               |
+| -------------------------- | -------------------- | --------------------------------------------------------- |
+| `SUPABASE_PUBLISHABLE_KEY` | `sb_publishable_...` | Single publishable key                                    |
+| `SUPABASE_SECRET_KEY`      | `sb_secret_...`      | Single secret key                                         |
+| `SUPABASE_JWKS_URL`        | `https://...`        | Remote JWKS endpoint (used when `SUPABASE_JWKS` is unset) |
 
 When both singular and plural forms are set, plural takes priority.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,25 +2,26 @@
 
 On Supabase Platform and Local Development (CLI), all variables are auto-provisioned — no configuration needed
 
-| Variable                    | Format                             | Description                           | Available in                      |
-| --------------------------- | ---------------------------------- | ------------------------------------- | --------------------------------- |
-| `SUPABASE_URL`              | `https://<ref>.supabase.co`        | Your Supabase project URL             | All                               |
-| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_..."}` | Named publishable keys as JSON object | All                               |
-| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_..."}`      | Named secret keys as JSON object      | All                               |
-| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`        | JSON Web Key Set for JWT verification | All                               |
-| `SUPABASE_PUBLISHABLE_KEY`  | `sb_publishable_...`               | Single publishable key (fallback)     | Self-hosted, if manually exported |
-| `SUPABASE_SECRET_KEY`       | `sb_secret_...`                    | Single secret key (fallback)          | Self-hosted, if manually exported |
+| Variable                    | Format                             | Description                                                  | Available in                      |
+| --------------------------- | ---------------------------------- | ------------------------------------------------------------ | --------------------------------- |
+| `SUPABASE_URL`              | `https://<ref>.supabase.co`        | Your Supabase project URL                                    | All                               |
+| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_..."}` | Named publishable keys as JSON object                        | All                               |
+| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_..."}`      | Named secret keys as JSON object                             | All                               |
+| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`        | Inline JSON Web Key Set for JWT verification                 | All                               |
+| `SUPABASE_JWKS_URL`         | `https://...`                      | Remote JWKS endpoint (alternative to inline `SUPABASE_JWKS`) | All                               |
+| `SUPABASE_PUBLISHABLE_KEY`  | `sb_publishable_...`               | Single publishable key (fallback)                            | Self-hosted, if manually exported |
+| `SUPABASE_SECRET_KEY`       | `sb_secret_...`                    | Single secret key (fallback)                                 | Self-hosted, if manually exported |
 
 ## Non-Supabase environments (Node.js, Bun, Cloudflare, self-hosted)
 
 Set these based on which auth modes your app uses:
 
-| Variable                   | Required when                             |
-| -------------------------- | ----------------------------------------- |
-| `SUPABASE_URL`             | Always                                    |
-| `SUPABASE_SECRET_KEY`      | `auth: 'secret'` or using `supabaseAdmin` |
-| `SUPABASE_PUBLISHABLE_KEY` | `auth: 'publishable'`                     |
-| `SUPABASE_JWKS`            | `auth: 'user'` (JWT verification)         |
+| Variable                               | Required when                             |
+| -------------------------------------- | ----------------------------------------- |
+| `SUPABASE_URL`                         | Always                                    |
+| `SUPABASE_SECRET_KEY`                  | `auth: 'secret'` or using `supabaseAdmin` |
+| `SUPABASE_PUBLISHABLE_KEY`             | `auth: 'publishable'`                     |
+| `SUPABASE_JWKS` or `SUPABASE_JWKS_URL` | `auth: 'user'` (JWT verification)         |
 
 ### Minimal `.env` example
 
@@ -75,22 +76,29 @@ The singular form is a convenience for the common case where you only have one k
 
 When both singular and plural forms are set, the plural form takes priority.
 
-## JWKS format
+## JWKS source
 
-`SUPABASE_JWKS` accepts three formats:
+JWT verification (`auth: 'user'`) needs a JWKS. There are two ways to provide one:
 
 ```
-# Standard JWKS format
+# Inline JSON — standard JWKS format
 SUPABASE_JWKS={"keys":[{"kty":"RSA","n":"...","e":"AQAB"}]}
 
-# Bare array (convenience)
+# Inline JSON — bare array (convenience, wrapped as { keys: [...] })
 SUPABASE_JWKS=[{"kty":"RSA","n":"...","e":"AQAB"}]
 
-# Remote JWKS URL — keys are fetched on demand and cached in memory.
-SUPABASE_JWKS=https://<ref>.supabase.co/auth/v1/.well-known/jwks.json
+# Remote JWKS endpoint — keys are fetched on demand and cached in memory.
+# HTTPS is required; plain http:// is rejected (a MITM on the JWKS fetch
+# could swap in an attacker-controlled key and forge JWTs that verify).
+SUPABASE_JWKS_URL=https://<ref>.supabase.co/auth/v1/.well-known/jwks.json
 ```
 
-When `SUPABASE_JWKS` is not set, JWT verification (`auth: 'user'`) is unavailable.
+### Resolution order
+
+1. `SUPABASE_JWKS` — when set, treated as authoritative inline JSON.
+2. `SUPABASE_JWKS_URL` — only checked when `SUPABASE_JWKS` is unset or empty.
+   Must be `https://`.
+3. Otherwise — `null`. JWT verification (`auth: 'user'`) is unavailable.
 
 ## Runtime-specific behavior
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -87,16 +87,21 @@ SUPABASE_JWKS={"keys":[{"kty":"RSA","n":"...","e":"AQAB"}]}
 SUPABASE_JWKS=[{"kty":"RSA","n":"...","e":"AQAB"}]
 
 # Remote JWKS endpoint — keys are fetched on demand and cached in memory.
-# HTTPS is required; plain http:// is rejected (a MITM on the JWKS fetch
-# could swap in an attacker-controlled key and forge JWTs that verify).
+# HTTPS is required for any non-loopback host; plain http:// is rejected
+# (a MITM on the JWKS fetch could swap in an attacker-controlled key and
+# forge JWTs that verify). http:// is allowed for loopback hosts only —
+# `localhost`, `127.0.0.0/8`, `::1` — to support the local Supabase CLI.
 SUPABASE_JWKS_URL=https://<ref>.supabase.co/auth/v1/.well-known/jwks.json
+
+# Local development against `supabase start`:
+SUPABASE_JWKS_URL=http://localhost:54321/auth/v1/.well-known/jwks.json
 ```
 
 ### Resolution order
 
 1. `SUPABASE_JWKS` — when set, treated as authoritative inline JSON.
 2. `SUPABASE_JWKS_URL` — only checked when `SUPABASE_JWKS` is unset or empty.
-   Must be `https://`.
+   Must be `https://`, except loopback hosts may use `http://`.
 3. Otherwise — `null`. JWT verification (`auth: 'user'`) is unavailable.
 
 ## Runtime-specific behavior

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,15 +2,14 @@
 
 On Supabase Platform and Local Development (CLI), all variables are auto-provisioned — no configuration needed
 
-| Variable                    | Format                             | Description                                                  | Available in                      |
-| --------------------------- | ---------------------------------- | ------------------------------------------------------------ | --------------------------------- |
-| `SUPABASE_URL`              | `https://<ref>.supabase.co`        | Your Supabase project URL                                    | All                               |
-| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_..."}` | Named publishable keys as JSON object                        | All                               |
-| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_..."}`      | Named secret keys as JSON object                             | All                               |
-| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`        | Inline JSON Web Key Set for JWT verification                 | All                               |
-| `SUPABASE_JWKS_URL`         | `https://...`                      | Remote JWKS endpoint (alternative to inline `SUPABASE_JWKS`) | All                               |
-| `SUPABASE_PUBLISHABLE_KEY`  | `sb_publishable_...`               | Single publishable key (fallback)                            | Self-hosted, if manually exported |
-| `SUPABASE_SECRET_KEY`       | `sb_secret_...`                    | Single secret key (fallback)                                 | Self-hosted, if manually exported |
+| Variable                    | Format                             | Description                                  | Available in                      |
+| --------------------------- | ---------------------------------- | -------------------------------------------- | --------------------------------- |
+| `SUPABASE_URL`              | `https://<ref>.supabase.co`        | Your Supabase project URL                    | All                               |
+| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_..."}` | Named publishable keys as JSON object        | All                               |
+| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_..."}`      | Named secret keys as JSON object             | All                               |
+| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`        | Inline JSON Web Key Set for JWT verification | All                               |
+| `SUPABASE_PUBLISHABLE_KEY`  | `sb_publishable_...`               | Single publishable key (fallback)            | Self-hosted, if manually exported |
+| `SUPABASE_SECRET_KEY`       | `sb_secret_...`                    | Single secret key (fallback)                 | Self-hosted, if manually exported |
 
 ## Non-Supabase environments (Node.js, Bun, Cloudflare, self-hosted)
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -77,7 +77,7 @@ When both singular and plural forms are set, the plural form takes priority.
 
 ## JWKS format
 
-`SUPABASE_JWKS` accepts two formats:
+`SUPABASE_JWKS` accepts three formats:
 
 ```
 # Standard JWKS format
@@ -85,6 +85,9 @@ SUPABASE_JWKS={"keys":[{"kty":"RSA","n":"...","e":"AQAB"}]}
 
 # Bare array (convenience)
 SUPABASE_JWKS=[{"kty":"RSA","n":"...","e":"AQAB"}]
+
+# Remote JWKS URL — keys are fetched on demand and cached in memory.
+SUPABASE_JWKS=https://<ref>.supabase.co/auth/v1/.well-known/jwks.json
 ```
 
 When `SUPABASE_JWKS` is not set, JWT verification (`auth: 'user'`) is unavailable.
@@ -176,7 +179,8 @@ interface SupabaseEnv {
   url: string
   publishableKeys: Record<string, string>
   secretKeys: Record<string, string>
-  jwks: JsonWebKeySet | null
+  // `URL` when SUPABASE_JWKS is a remote endpoint, `JsonWebKeySet` for inline keys
+  jwks: JsonWebKeySet | URL | null
 }
 ```
 

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -88,6 +88,16 @@ describe('resolveEnv', () => {
     expect(result.data!.jwks).toBeNull()
   })
 
+  it.each([
+    ['unclosed IPv6 bracket', 'https://[invalid'],
+    ['scheme only, no host', 'https://'],
+  ])('returns null for malformed SUPABASE_JWKS_URL (%s)', (_label, value) => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS_URL', value)
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeNull()
+  })
+
   it('trims whitespace around SUPABASE_JWKS_URL values', () => {
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
     vi.stubEnv('SUPABASE_JWKS_URL', '   https://example.com/jwks.json\n')

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -81,12 +81,36 @@ describe('resolveEnv', () => {
     )
   })
 
-  it('rejects http SUPABASE_JWKS_URL (MITM risk on insecure JWKS fetch)', () => {
-    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
-    vi.stubEnv('SUPABASE_JWKS_URL', 'http://localhost:54321/auth/v1/jwks')
-    const result = resolveEnv()
-    expect(result.data!.jwks).toBeNull()
-  })
+  it.each([
+    ['plain hostname', 'http://example.com/jwks.json'],
+    ['public IP', 'http://1.2.3.4/jwks.json'],
+    ['private IP (non-loopback)', 'http://10.0.0.1/jwks.json'],
+    ['localhost prefix attack', 'http://localhost.evil.com/jwks.json'],
+  ])(
+    'rejects http SUPABASE_JWKS_URL on non-loopback host (%s)',
+    (_label, value) => {
+      vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+      vi.stubEnv('SUPABASE_JWKS_URL', value)
+      const result = resolveEnv()
+      expect(result.data!.jwks).toBeNull()
+    },
+  )
+
+  it.each([
+    ['localhost', 'http://localhost:54321/auth/v1/.well-known/jwks.json'],
+    ['127.0.0.1', 'http://127.0.0.1:54321/auth/v1/jwks'],
+    ['127.x range', 'http://127.0.0.5/jwks.json'],
+    ['::1', 'http://[::1]:54321/jwks.json'],
+    ['*.localhost subdomain', 'http://api.localhost/jwks.json'],
+  ])(
+    'allows http SUPABASE_JWKS_URL for loopback host (%s)',
+    (_label, value) => {
+      vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+      vi.stubEnv('SUPABASE_JWKS_URL', value)
+      const result = resolveEnv()
+      expect(result.data!.jwks).toBeInstanceOf(URL)
+    },
+  )
 
   it.each([
     ['unclosed IPv6 bracket', 'https://[invalid'],

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -68,10 +68,10 @@ describe('resolveEnv', () => {
     expect(result.data!.jwks).toBeNull()
   })
 
-  it('parses https URL JWKS into a URL object', () => {
+  it('parses SUPABASE_JWKS_URL into a URL object', () => {
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
     vi.stubEnv(
-      'SUPABASE_JWKS',
+      'SUPABASE_JWKS_URL',
       'https://test.supabase.co/auth/v1/.well-known/jwks.json',
     )
     const result = resolveEnv()
@@ -81,21 +81,53 @@ describe('resolveEnv', () => {
     )
   })
 
-  it('rejects http URL JWKS (MITM risk on insecure JWKS fetch)', () => {
+  it('rejects http SUPABASE_JWKS_URL (MITM risk on insecure JWKS fetch)', () => {
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
-    vi.stubEnv('SUPABASE_JWKS', 'http://localhost:54321/auth/v1/jwks')
+    vi.stubEnv('SUPABASE_JWKS_URL', 'http://localhost:54321/auth/v1/jwks')
     const result = resolveEnv()
     expect(result.data!.jwks).toBeNull()
   })
 
-  it('trims whitespace around URL JWKS values', () => {
+  it('trims whitespace around SUPABASE_JWKS_URL values', () => {
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
-    vi.stubEnv('SUPABASE_JWKS', '   https://example.com/jwks.json\n')
+    vi.stubEnv('SUPABASE_JWKS_URL', '   https://example.com/jwks.json\n')
     const result = resolveEnv()
     expect(result.data!.jwks).toBeInstanceOf(URL)
     expect((result.data!.jwks as URL).href).toBe(
       'https://example.com/jwks.json',
     )
+  })
+
+  it('rejects a URL value placed in SUPABASE_JWKS (mixed-type protection)', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS', 'https://example.com/jwks.json')
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeNull()
+  })
+
+  it('SUPABASE_JWKS wins over SUPABASE_JWKS_URL when both are set', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    const inline = { keys: [{ kty: 'RSA', n: 'inline', e: 'AQAB' }] }
+    vi.stubEnv('SUPABASE_JWKS', JSON.stringify(inline))
+    vi.stubEnv('SUPABASE_JWKS_URL', 'https://example.com/jwks.json')
+    const result = resolveEnv()
+    expect(result.data!.jwks).toEqual(inline)
+  })
+
+  it('does not fall through to SUPABASE_JWKS_URL when SUPABASE_JWKS is malformed', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS', 'not-json')
+    vi.stubEnv('SUPABASE_JWKS_URL', 'https://example.com/jwks.json')
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeNull()
+  })
+
+  it('falls through to SUPABASE_JWKS_URL when SUPABASE_JWKS is unset or empty', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS', '')
+    vi.stubEnv('SUPABASE_JWKS_URL', 'https://example.com/jwks.json')
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeInstanceOf(URL)
   })
 
   it('passes URL overrides through unchanged', () => {

--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveEnv } from './resolve-env.js'
 import { MissingSupabaseURLError } from '../errors.js'
+import type { JsonWebKeySet } from '../types.js'
 
 describe('resolveEnv', () => {
   afterEach(() => {
@@ -65,6 +66,45 @@ describe('resolveEnv', () => {
     vi.stubEnv('SUPABASE_JWKS', 'not-json')
     const result = resolveEnv()
     expect(result.data!.jwks).toBeNull()
+  })
+
+  it('parses https URL JWKS into a URL object', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv(
+      'SUPABASE_JWKS',
+      'https://test.supabase.co/auth/v1/.well-known/jwks.json',
+    )
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeInstanceOf(URL)
+    expect((result.data!.jwks as URL).href).toBe(
+      'https://test.supabase.co/auth/v1/.well-known/jwks.json',
+    )
+  })
+
+  it('rejects http URL JWKS (MITM risk on insecure JWKS fetch)', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS', 'http://localhost:54321/auth/v1/jwks')
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeNull()
+  })
+
+  it('trims whitespace around URL JWKS values', () => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co')
+    vi.stubEnv('SUPABASE_JWKS', '   https://example.com/jwks.json\n')
+    const result = resolveEnv()
+    expect(result.data!.jwks).toBeInstanceOf(URL)
+    expect((result.data!.jwks as URL).href).toBe(
+      'https://example.com/jwks.json',
+    )
+  })
+
+  it('passes URL overrides through unchanged', () => {
+    const url = new URL('https://example.com/jwks.json')
+    const result = resolveEnv({
+      url: 'https://test.supabase.co',
+      jwks: url,
+    })
+    expect(result.data!.jwks).toBe(url)
   })
 
   it.each([
@@ -138,11 +178,12 @@ describe('resolveEnv', () => {
       default: 'sb_secret_fake_default_key_val',
       internal: 'sb_secret_fake_internal_key',
     })
-    expect(result.data!.jwks!.keys).toHaveLength(2)
-    expect((result.data!.jwks!.keys[0] as Record<string, unknown>).kid).toBe(
+    const jwks = result.data!.jwks as JsonWebKeySet
+    expect(jwks.keys).toHaveLength(2)
+    expect((jwks.keys[0] as Record<string, unknown>).kid).toBe(
       'cb770052-bdd3-4f5e-8d6f-8836046b7c93',
     )
-    expect((result.data!.jwks!.keys[1] as Record<string, unknown>).kid).toBe(
+    expect((jwks.keys[1] as Record<string, unknown>).kid).toBe(
       '9a9933f7-e18f-4d6f-a791-9a992845a27b',
     )
   })

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -78,18 +78,38 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | null {
 }
 
 /**
- * Parses a JWKS endpoint URL. Only `https://` is accepted: a MITM on the
- * JWKS fetch could swap in an attacker-controlled key and forge JWTs that
- * pass verification. Returns `null` for missing, non-https, or malformed input.
+ * Returns true if the hostname is a loopback address — `localhost`,
+ * `*.localhost`, `127.0.0.0/8`, or `::1`. Browsers treat these as secure
+ * contexts because traffic never leaves the machine.
+ *
+ * @internal
+ */
+function isLoopbackHost(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) return true
+  // URL.hostname keeps the brackets for IPv6 literals (e.g. "[::1]").
+  if (hostname === '[::1]') return true
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)) return true
+  return false
+}
+
+/**
+ * Parses a JWKS endpoint URL. `https://` is always accepted. Plain `http://`
+ * is accepted only for loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) so
+ * the Supabase CLI flow works against `http://localhost:54321`. For any
+ * other host, http is rejected: a MITM on the JWKS fetch could swap in an
+ * attacker-controlled key and forge JWTs that pass verification. Returns
+ * `null` for missing or malformed input.
  *
  * @internal
  */
 function parseJwksUrl(raw: string | undefined): URL | null {
   if (!raw) return null
   const trimmed = raw.trim()
-  if (!trimmed.startsWith('https://')) return null
   try {
-    return new URL(trimmed)
+    const url = new URL(trimmed)
+    if (url.protocol === 'https:') return url
+    if (url.protocol === 'http:' && isLoopbackHost(url.hostname)) return url
+    return null
   } catch {
     return null
   }

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -58,15 +58,30 @@ function resolveKeys(
 }
 
 /**
- * Parses a JWKS JSON string into a {@link JsonWebKeySet}.
- * Accepts both `{ keys: [...] }` and bare `[...]` array formats.
- * Returns `null` if the input is missing or malformed.
+ * Parses a `SUPABASE_JWKS` env value.
+ *
+ * Accepted forms:
+ * - An `https://` URL — returned as a {@link URL}; keys are fetched at verify time.
+ *   Plain `http://` is rejected: a MITM on the JWKS fetch could swap in an
+ *   attacker-controlled key and forge JWTs that pass verification.
+ * - JSON `{ keys: [...] }` — returned as a {@link JsonWebKeySet}.
+ * - JSON bare array `[...]` — wrapped as `{ keys: [...] }`.
+ * - Anything else (missing or malformed) — returns `null`.
+ *
  * @internal
  */
-function parseJwks(raw: string | undefined): JsonWebKeySet | null {
+function parseJwks(raw: string | undefined): JsonWebKeySet | URL | null {
   if (!raw) return null
+  const trimmed = raw.trim()
+  if (trimmed.startsWith('https://')) {
+    try {
+      return new URL(trimmed)
+    } catch {
+      return null
+    }
+  }
   try {
-    const parsed = JSON.parse(raw)
+    const parsed = JSON.parse(trimmed)
     // Support both { keys: [...] } and bare array [...] formats
     if (Array.isArray(parsed)) return { keys: parsed }
     if (parsed?.keys && Array.isArray(parsed.keys))

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -58,31 +58,16 @@ function resolveKeys(
 }
 
 /**
- * Parses a `SUPABASE_JWKS` env value.
- *
- * Accepted forms:
- * - An `https://` URL — returned as a {@link URL}; keys are fetched at verify time.
- *   Plain `http://` is rejected: a MITM on the JWKS fetch could swap in an
- *   attacker-controlled key and forge JWTs that pass verification.
- * - JSON `{ keys: [...] }` — returned as a {@link JsonWebKeySet}.
- * - JSON bare array `[...]` — wrapped as `{ keys: [...] }`.
- * - Anything else (missing or malformed) — returns `null`.
+ * Parses an inline JWKS JSON string. Accepts `{ keys: [...] }` or a bare
+ * array `[...]` (wrapped as `{ keys: [...] }`). Returns `null` for missing
+ * or malformed input.
  *
  * @internal
  */
-function parseJwks(raw: string | undefined): JsonWebKeySet | URL | null {
+function parseJwks(raw: string | undefined): JsonWebKeySet | null {
   if (!raw) return null
-  const trimmed = raw.trim()
-  if (trimmed.startsWith('https://')) {
-    try {
-      return new URL(trimmed)
-    } catch {
-      return null
-    }
-  }
   try {
-    const parsed = JSON.parse(trimmed)
-    // Support both { keys: [...] } and bare array [...] formats
+    const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) return { keys: parsed }
     if (parsed?.keys && Array.isArray(parsed.keys))
       return parsed as JsonWebKeySet
@@ -93,11 +78,51 @@ function parseJwks(raw: string | undefined): JsonWebKeySet | URL | null {
 }
 
 /**
+ * Parses a JWKS endpoint URL. Only `https://` is accepted: a MITM on the
+ * JWKS fetch could swap in an attacker-controlled key and forge JWTs that
+ * pass verification. Returns `null` for missing, non-https, or malformed input.
+ *
+ * @internal
+ */
+function parseJwksUrl(raw: string | undefined): URL | null {
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith('https://')) return null
+  try {
+    return new URL(trimmed)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolves the JWKS source from `SUPABASE_JWKS` (inline JSON) or
+ * `SUPABASE_JWKS_URL` (https endpoint). `SUPABASE_JWKS` wins when set;
+ * `SUPABASE_JWKS_URL` is only consulted if `SUPABASE_JWKS` is absent. Each
+ * variable is treated as authoritative — if set but malformed, the result is
+ * `null` and the other variable is *not* consulted as a fallback.
+ *
+ * @internal
+ */
+function resolveJwks(): JsonWebKeySet | URL | null {
+  const rawJwks = getEnvVar('SUPABASE_JWKS')
+  if (rawJwks && rawJwks.trim()) {
+    return parseJwks(rawJwks)
+  }
+  const rawJwksUrl = getEnvVar('SUPABASE_JWKS_URL')
+  if (rawJwksUrl && rawJwksUrl.trim()) {
+    return parseJwksUrl(rawJwksUrl)
+  }
+  return null
+}
+
+/**
  * Resolves Supabase environment configuration from runtime environment variables.
  *
  * Reads `SUPABASE_URL`, keys (`SUPABASE_PUBLISHABLE_KEYS` / `SUPABASE_SECRET_KEYS`),
- * and `SUPABASE_JWKS`. Works across Deno, Node.js, and Bun. For Cloudflare Workers,
- * use `overrides` or enable node-compat.
+ * and the JWKS source (`SUPABASE_JWKS` for inline keys, or `SUPABASE_JWKS_URL`
+ * for a remote endpoint). Works across Deno, Node.js, and Bun. For Cloudflare
+ * Workers, use `overrides` or enable node-compat.
  *
  * @param overrides - Partial values that take precedence over env vars.
  * @returns `{ data: SupabaseEnv, error: null }` on success, `{ data: null, error: EnvError }` on failure.
@@ -131,7 +156,7 @@ export function resolveEnv(
     secretKeys:
       overrides?.secretKeys ??
       resolveKeys('SUPABASE_SECRET_KEY', 'SUPABASE_SECRET_KEYS'),
-    jwks: overrides?.jwks ?? parseJwks(getEnvVar('SUPABASE_JWKS')),
+    jwks: overrides?.jwks ?? resolveJwks(),
   }
 
   return { data, error: null }

--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -456,6 +456,53 @@ describe('verifyCredentials', () => {
       expect(result.error).not.toBeNull()
       expect(result.error!.code).toBe(InvalidCredentialsError)
     })
+
+    it('replaces the cached resolver when the URL changes', async () => {
+      // Second tenant with its own keypair. The resolver cache is single-slot
+      // keyed by URL string; if a refactor breaks that comparison, the second
+      // verify would (incorrectly) reuse the first URL's resolver and fail.
+      const keyPairB = await generateKeyPair('RS256')
+      const publicJwkB = await exportJWK(keyPairB.publicKey)
+      publicJwkB.alg = 'RS256'
+      publicJwkB.use = 'sig'
+      publicJwkB.kid = 'remote-key-b'
+      const jwksB: JsonWebKeySet = { keys: [publicJwkB] }
+      const tokenB = await new SignJWT({
+        sub: 'user-remote-b',
+        role: 'authenticated',
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'remote-key-b' })
+        .setIssuedAt()
+        .setExpirationTime('1h')
+        .sign(keyPairB.privateKey)
+
+      const urlA = new URL('https://jwks-switch-a.example/jwks.json')
+      const urlB = new URL('https://jwks-switch-b.example/jwks.json')
+
+      fetchMock.mockImplementation(async (input: URL | string) => {
+        const href = input instanceof URL ? input.href : String(input)
+        const body = href === urlB.href ? jwksB : jwks
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      })
+
+      const a = await verifyCredentials(
+        { token: validToken, apikey: null },
+        { auth: 'user', env: makeEnv({ jwks: urlA }) },
+      )
+      const b = await verifyCredentials(
+        { token: tokenB, apikey: null },
+        { auth: 'user', env: makeEnv({ jwks: urlB }) },
+      )
+
+      expect(a.error).toBeNull()
+      expect(a.data!.userClaims!.id).toBe('user-remote')
+      expect(b.error).toBeNull()
+      expect(b.data!.userClaims!.id).toBe('user-remote-b')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('parseAuthMode edge cases', () => {

--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -1,5 +1,13 @@
 import { exportJWK, generateKeyPair, SignJWT } from 'jose'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import type { Credentials, JsonWebKeySet, SupabaseEnv } from '../types.js'
 import { verifyCredentials } from './verify-credentials.js'
@@ -341,6 +349,109 @@ describe('verifyCredentials', () => {
       const result = await verifyCredentials(creds, {
         auth: 'user',
         env: makeEnv({ jwks: expiredJwks }),
+      })
+      expect(result.error).not.toBeNull()
+      expect(result.error!.code).toBe(InvalidCredentialsError)
+    })
+  })
+
+  describe('user mode with remote JWKS URL', () => {
+    let privateKey: CryptoKey
+    let jwks: JsonWebKeySet
+    let validToken: string
+    let fetchMock: ReturnType<typeof vi.fn>
+
+    beforeAll(async () => {
+      const keyPair = await generateKeyPair('RS256')
+      privateKey = keyPair.privateKey
+      const publicJwk = await exportJWK(keyPair.publicKey)
+      publicJwk.alg = 'RS256'
+      publicJwk.use = 'sig'
+      publicJwk.kid = 'remote-key-1'
+      jwks = { keys: [publicJwk] }
+
+      validToken = await new SignJWT({
+        sub: 'user-remote',
+        role: 'authenticated',
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'remote-key-1' })
+        .setIssuedAt()
+        .setExpirationTime('1h')
+        .sign(privateKey)
+    })
+
+    beforeEach(() => {
+      fetchMock = vi.fn(
+        async () =>
+          new Response(JSON.stringify(jwks), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      )
+      vi.stubGlobal('fetch', fetchMock)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('fetches keys from the URL and verifies a valid JWT', async () => {
+      const creds: Credentials = { token: validToken, apikey: null }
+      const result = await verifyCredentials(creds, {
+        auth: 'user',
+        env: makeEnv({
+          jwks: new URL(
+            'https://jwks-fetch-success.example/auth/v1/.well-known/jwks.json',
+          ),
+        }),
+      })
+      expect(result.error).toBeNull()
+      expect(result.data!.userClaims!.id).toBe('user-remote')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('reuses the cached resolver for the same URL across requests', async () => {
+      // Distinct URL so jose's per-resolver cooldown is fresh for this test
+      const jwksUrl = new URL('https://jwks-cache.example/jwks.json')
+      const creds: Credentials = { token: validToken, apikey: null }
+
+      const first = await verifyCredentials(creds, {
+        auth: 'user',
+        env: makeEnv({ jwks: jwksUrl }),
+      })
+      const second = await verifyCredentials(creds, {
+        auth: 'user',
+        env: makeEnv({ jwks: jwksUrl }),
+      })
+
+      expect(first.error).toBeNull()
+      expect(second.error).toBeNull()
+      // jose's cooldownDuration (default 30s) keeps the second call from re-fetching.
+      // What we're guarding against is *re-creating* the resolver on every request,
+      // which would re-fetch every time.
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects an invalid JWT verified against the remote JWKS', async () => {
+      const creds: Credentials = { token: 'garbage.jwt.token', apikey: null }
+      const result = await verifyCredentials(creds, {
+        auth: 'user',
+        env: makeEnv({
+          jwks: new URL('https://jwks-bad-token.example/jwks.json'),
+        }),
+      })
+      expect(result.error).not.toBeNull()
+      expect(result.error!.code).toBe(InvalidCredentialsError)
+    })
+
+    it('rejects when the remote JWKS endpoint fails', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      const creds: Credentials = { token: validToken, apikey: null }
+      const result = await verifyCredentials(creds, {
+        auth: 'user',
+        env: makeEnv({
+          jwks: new URL('https://jwks-server-error.example/jwks.json'),
+        }),
       })
       expect(result.error).not.toBeNull()
       expect(result.error!.code).toBe(InvalidCredentialsError)

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -1,4 +1,9 @@
-import { createLocalJWKSet, jwtVerify } from 'jose'
+import {
+  createLocalJWKSet,
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTVerifyGetKey,
+} from 'jose'
 
 import { AuthError, Errors, InvalidCredentialsError } from '../errors.js'
 import type {
@@ -6,6 +11,7 @@ import type {
   AuthModeWithKey,
   AuthResult,
   Credentials,
+  JsonWebKeySet,
   JWTClaims,
   SupabaseEnv,
   UserClaims,
@@ -84,6 +90,30 @@ function jwtClaimsToUserClaims(jwtClaims: JWTClaims): UserClaims {
 }
 
 const INVALID = Symbol('invalid')
+
+let remoteJwksResolver: { url: string; resolver: JWTVerifyGetKey } | undefined =
+  undefined
+
+/**
+ * Returns a key resolver for the given JWKS source.
+ *
+ * For a {@link URL}, the underlying `createRemoteJWKSet` resolver is cached
+ * across requests so `jose`'s built-in cooldown / max-age caching is
+ * preserved. Local JWKS objects are wrapped on every call — they're trivially
+ * cheap and the object identity may change across requests.
+ *
+ * @internal
+ */
+function getJwksResolver(jwks: JsonWebKeySet | URL): JWTVerifyGetKey {
+  if (jwks instanceof URL) {
+    const url = jwks.toString()
+    if (remoteJwksResolver?.url !== url) {
+      remoteJwksResolver = { url, resolver: createRemoteJWKSet(jwks) }
+    }
+    return remoteJwksResolver.resolver
+  }
+  return createLocalJWKSet(jwks)
+}
 
 /**
  * Attempts to authenticate credentials against a single auth mode.
@@ -180,7 +210,7 @@ async function tryMode(
       if (!credentials.token) return null
       if (!env.jwks) return null
       try {
-        const jwkSet = createLocalJWKSet(env.jwks)
+        const jwkSet = getJwksResolver(env.jwks)
         const { payload } = await jwtVerify(credentials.token, jwkSet)
         if (typeof payload.sub !== 'string') {
           return INVALID

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,15 +85,18 @@ export interface SupabaseEnv {
   secretKeys: Record<string, string>
 
   /**
-   * JSON Web Key Set used for JWT verification. Sourced from `SUPABASE_JWKS`.
+   * JWKS source used for JWT verification.
    *
-   * Three forms are accepted:
-   * - A {@link JsonWebKeySet} object — keys are matched in-process.
-   * - A {@link URL} pointing at a remote JWKS endpoint — keys are fetched from
-   *   the URL and cached in memory (cooldown / max-age handled by `jose`).
-   *   String env-var values that start with `https://` resolve to this form;
-   *   plain `http://` is rejected to prevent MITM attacks on the JWKS fetch.
-   * - `null` when no JWKS is configured (JWT verification will be unavailable).
+   * Sourced from one of (in priority order):
+   * - `SUPABASE_JWKS` — inline JSON. Resolves to a {@link JsonWebKeySet}.
+   * - `SUPABASE_JWKS_URL` — https endpoint. Resolves to a {@link URL}; keys
+   *   are fetched lazily and cached in memory (cooldown / max-age handled by
+   *   `jose`). Only `https://` is accepted — plain `http://` is rejected to
+   *   prevent MITM swap-in of a forged signing key.
+   *
+   * `null` when no JWKS is configured (JWT verification will be unavailable).
+   * Each env var is authoritative when set: a malformed value resolves to
+   * `null` rather than falling through to the other variable.
    */
   jwks: JsonWebKeySet | URL | null
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,10 +86,16 @@ export interface SupabaseEnv {
 
   /**
    * JSON Web Key Set used for JWT verification. Sourced from `SUPABASE_JWKS`.
-   * Accepts both `{ keys: [...] }` and bare `[...]` array formats.
-   * `null` when no JWKS is configured (JWT verification will be unavailable).
+   *
+   * Three forms are accepted:
+   * - A {@link JsonWebKeySet} object — keys are matched in-process.
+   * - A {@link URL} pointing at a remote JWKS endpoint — keys are fetched from
+   *   the URL and cached in memory (cooldown / max-age handled by `jose`).
+   *   String env-var values that start with `https://` resolve to this form;
+   *   plain `http://` is rejected to prevent MITM attacks on the JWKS fetch.
+   * - `null` when no JWKS is configured (JWT verification will be unavailable).
    */
-  jwks: JsonWebKeySet | null
+  jwks: JsonWebKeySet | URL | null
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,10 +89,12 @@ export interface SupabaseEnv {
    *
    * Sourced from one of (in priority order):
    * - `SUPABASE_JWKS` — inline JSON. Resolves to a {@link JsonWebKeySet}.
-   * - `SUPABASE_JWKS_URL` — https endpoint. Resolves to a {@link URL}; keys
+   * - `SUPABASE_JWKS_URL` — remote endpoint. Resolves to a {@link URL}; keys
    *   are fetched lazily and cached in memory (cooldown / max-age handled by
-   *   `jose`). Only `https://` is accepted — plain `http://` is rejected to
-   *   prevent MITM swap-in of a forged signing key.
+   *   `jose`). `https://` is always accepted; plain `http://` is accepted
+   *   only for loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) to support
+   *   the Supabase CLI. Any other `http://` URL is rejected to prevent MITM
+   *   swap-in of a forged signing key.
    *
    * `null` when no JWKS is configured (JWT verification will be unavailable).
    * Each env var is authoritative when set: a malformed value resolves to


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: Support for JWKS urls

##
- I added a inline variable that stores the remote cache from Jose when called once, Thinking here was that a subsequent serverless runtimes make requests in the warm pool we don't need to call it over and over again to reduce latency and rely on the underlying lib for caching 
- Added some tests with the help of claude