### PR TITLE
chore(security): harden supply chain and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.28.0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
 
       - run: pnpm typecheck
 
       - run: pnpm lint
 
       - name: Verify JSR packaging
-        run: pnpm dlx jsr publish --dry-run --allow-dirty
+        run: pnpm dlx jsr@0.14.3 publish --dry-run --allow-dirty

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -17,11 +17,10 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: 10.28.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -37,4 +36,4 @@ jobs:
 
       - name: Publish preview packages
         run: |
-          npx pkg-pr-new@latest publish
+          npx pkg-pr-new@0.0.71 publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Determine version
         id: version
@@ -93,10 +94,8 @@ jobs:
           npm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         if: ${{ steps.version.outputs.skip != 'true' }}
-        with:
-          version: 10.28.0
 
       - name: Install dependencies
         if: ${{ steps.version.outputs.skip != 'true' }}
@@ -126,13 +125,12 @@ jobs:
             exit 1
           fi
           rm -f "$NPM_VIEW_STDERR"
-          # TODO(@mandarini): add back --provenance once repo is OSS
-          npm publish --access public --tag "${{ steps.version.outputs.tag }}"
+          npm publish --access public --provenance --tag "${{ steps.version.outputs.tag }}"
 
       - name: Publish to JSR
         if: ${{ steps.version.outputs.skip != 'true' }}
         continue-on-error: true
-        run: npx jsr publish --allow-dirty
+        run: npx jsr@0.14.3 publish --allow-dirty
 
       - name: Create GitHub pre-release
         if: ${{ steps.version.outputs.tag == 'rc' }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners for the entire repository
+* @supabase/edge-functions @supabase/admin @supabase/security

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "engines": {
     "node": ">=20"
   },
+  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
@@ -67,11 +68,6 @@
   "simple-git-hooks": {
     "pre-commit": "pnpm pretty-quick --staged",
     "commit-msg": "pnpm commitlint --edit \"$1\""
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "simple-git-hooks"
-    ]
   },
   "peerDependencies": {
     "@supabase/supabase-js": "^2.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@supabase/*'
+blockExoticSubdeps: true
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: true


### PR DESCRIPTION
Supply chain hardening prompted by the TanStack/router compromise on 2026-05-11 ([TanStack/router#7383](https://github.com/TanStack/router/issues/7383)).

## What changed

**Pnpm config (`pnpm-workspace.yaml`)**
- `minimumReleaseAge: 10080` (7-day quarantine on new dep versions)
- `minimumReleaseAgeExclude: ['@supabase/*']` (internal packages bypass the quarantine)
- `blockExoticSubdeps: true` (refuse `github:` / `git+` / `file:` transitive deps, the exact vector TanStack hit)
- `allowBuilds` (explicit per-package postinstall allowlist: `simple-git-hooks: true`, `esbuild: false`)

**Pnpm version pinning**
- Added `packageManager` field in `package.json` with sha512 integrity hash (pnpm@11.0.8)
- Bumped `pnpm/action-setup` v5.0.0 -> v6.0.5 (SHA-pinned), now reads version from `packageManager`
- Fixes local-vs-CI drift (was 10.28.0 in CI, 11.x local)

**Workflow hardening**
- `persist-credentials: false` on every `actions/checkout`
- `pnpm install --frozen-lockfile` in `ci.yml` (was unpinned)
- Pinned floating CLI refs: `pkg-pr-new@0.0.71`, `jsr@0.14.3`
- Enabled `npm publish --provenance`