### PR TITLE
chore(ci): split publish from build, drop Actions cache from privileged workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
-          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,20 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write # required for npm trusted publishing
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  release-please:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      skip: ${{ steps.version.outputs.skip }}
     steps:
       - name: Generate GitHub App token
         id: generate-token
@@ -43,6 +45,7 @@ jobs:
           RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
           RELEASE_VERSION: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
           PR_HEAD_BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
 
@@ -70,7 +73,7 @@ jobs:
               exit 1
             fi
 
-            VERSION="${NEXT_VERSION}-rc.${{ github.run_number }}"
+            VERSION="${NEXT_VERSION}-rc.${RUN_NUMBER}"
             TAG="rc"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -81,17 +84,6 @@ jobs:
         if: ${{ steps.version.outputs.skip != 'true' }}
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install latest npm (user prefix)
-        if: ${{ steps.version.outputs.skip != 'true' }}
-        run: |
-          mkdir -p "$HOME/.npm-global"
-          npm config set prefix "$HOME/.npm-global"
-          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
-
-          npm install -g npm@latest
-          npm --version
 
       - name: Setup pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
@@ -103,29 +95,29 @@ jobs:
 
       - name: Stamp version
         if: ${{ steps.version.outputs.skip != 'true' }}
-        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Build
         if: ${{ steps.version.outputs.skip != 'true' }}
         run: pnpm build
 
-      - name: Publish to npm
+      - name: Pack tarball
         if: ${{ steps.version.outputs.skip != 'true' }}
         run: |
-          set -euo pipefail
-          NPM_VIEW_STDERR=$(mktemp)
-          EXISTING=$(npm view "@supabase/server@${{ steps.version.outputs.version }}" version 2>"$NPM_VIEW_STDERR") || STATUS=$?
-          if [ -n "$EXISTING" ]; then
-            echo "Version ${{ steps.version.outputs.version }} already published, skipping."
-            rm -f "$NPM_VIEW_STDERR"
-            exit 0
-          elif [ "${STATUS:-0}" -ne 0 ] && ! grep -qiE 'E404|not found' "$NPM_VIEW_STDERR"; then
-            cat "$NPM_VIEW_STDERR"
-            rm -f "$NPM_VIEW_STDERR"
-            exit 1
-          fi
-          rm -f "$NPM_VIEW_STDERR"
-          npm publish --access public --provenance --tag "${{ steps.version.outputs.tag }}"
+          mkdir -p ./pack
+          npm pack --pack-destination ./pack
+          ls -la ./pack/
+
+      - name: Upload tarball artifact
+        if: ${{ steps.version.outputs.skip != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball
+          path: ./pack/*.tgz
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Publish to JSR
         if: ${{ steps.version.outputs.skip != 'true' }}
@@ -136,8 +128,58 @@ jobs:
         if: ${{ steps.version.outputs.tag == 'rc' }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          gh release create "server-v${{ steps.version.outputs.version }}" \
-            --title "server-v${{ steps.version.outputs.version }}" \
+          gh release create "server-v$VERSION" \
+            --title "server-v$VERSION" \
             --generate-notes \
             --prerelease
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ needs.build.outputs.skip != 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install latest npm (user prefix)
+        run: |
+          mkdir -p "$HOME/.npm-global"
+          npm config set prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+          npm install -g npm@latest
+          npm --version
+
+      - name: Download tarball artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-tarball
+          path: ./publish
+
+      - name: Publish to npm
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+          TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          NPM_VIEW_STDERR=$(mktemp)
+          EXISTING=$(npm view "@supabase/server@$VERSION" version 2>"$NPM_VIEW_STDERR") || STATUS=$?
+          if [ -n "$EXISTING" ]; then
+            echo "Version $VERSION already published, skipping."
+            rm -f "$NPM_VIEW_STDERR"
+            exit 0
+          elif [ "${STATUS:-0}" -ne 0 ] && ! grep -qiE 'E404|not found' "$NPM_VIEW_STDERR"; then
+            cat "$NPM_VIEW_STDERR"
+            rm -f "$NPM_VIEW_STDERR"
+            exit 1
+          fi
+          rm -f "$NPM_VIEW_STDERR"
+          npm publish ./publish/*.tgz --access public --provenance --tag "$TAG"


### PR DESCRIPTION
Closes the OIDC-theft and cache-poisoning vectors that the TanStack/router compromise (2026-05-11) and Adnan Khan's [cache-poisoning research](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/) describe.

## What changed

**`release.yml` split into two jobs:**
- `build` — `contents: write` + `pull-requests: write` (release-please). Runs install/build/pack and uploads the `.tgz` as an artifact. **No `id-token`.**
- `publish-npm` — `needs: build`, only job with `id-token: write`. Downloads the tarball into `./publish/` (scratch dir per GHSL Part 4), runs `npm publish --provenance` on the `.tgz`. Never runs `pnpm install` or any third-party code.

JSR publish and GH pre-release stay in the build job (JSR uses its own OIDC binding scoped to JSR, not npm).

**Dropped `cache: pnpm` from `docs.yml` and `ci.yml`:**
A compromised dep on a main-branch workflow can steal the GitHub Actions cache token and poison entries that other privileged workflows on main will restore. `release.yml` no longer caches; `docs.yml` had `id-token: write` for Pages OIDC and was the main remaining target. `ci.yml` is low-impact but dropped for consistency. `preview-release.yml` runs in fork cache scope (forks cannot write to main's cache) and is unaffected.

**Defense-in-depth:** moved all `${{ ... }}` substitutions in inline shell scripts to `env:` blocks (GHSL Part 2 pattern), even though upstream values are regex-validated.

## What this does NOT close

A compromised dep on the `build` job can still corrupt `dist/`. The poisoned artifact would then flow to `publish-npm` and ship with a valid OIDC token and provenance attestation. Closing this requires a required-reviewer Environment on the publish job — deferred to a follow-up.

## Verification

- All four workflow YAMLs validate.
- Tests + typecheck + lint all green.
- Local `npm pack` produces a 59 KB tarball with the expected contents.

End-to-end verification needs a release-please cycle (open a release PR, merge, watch the two jobs).