### PR TITLE
feat(gates/postgres): withPostgres and withPostgresAdmin

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -7,6 +7,7 @@
     "./core/adapters": "./src/core/adapters/index.ts",
     "./gates/auth-hook": "./src/gates/auth-hook/index.ts",
     "./gates/feature-flag": "./src/gates/feature-flag/index.ts",
+    "./gates/postgres": "./src/gates/postgres/index.ts",
     "./adapters/hono": "./src/adapters/hono/index.ts",
     "./adapters/h3": "./src/adapters/h3/index.ts",
     "./adapters/elysia": "./src/adapters/elysia/index.ts",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
       "import": "./dist/gates/feature-flag/index.mjs",
       "require": "./dist/gates/feature-flag/index.cjs"
     },
+    "./gates/postgres": {
+      "types": "./dist/gates/postgres/index.d.mts",
+      "import": "./dist/gates/postgres/index.mjs",
+      "require": "./dist/gates/postgres/index.cjs"
+    },
     "./adapters/hono": {
       "types": "./dist/adapters/hono/index.d.mts",
       "import": "./dist/adapters/hono/index.mjs",
@@ -97,9 +102,9 @@
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@supabase/supabase-js": "^2.0.0",
+    "elysia": "^1.4.0",
     "h3": "^2.0.0",
-    "hono": "^4.0.0",
-    "elysia": "^1.4.0"
+    "hono": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {
@@ -125,9 +130,10 @@
     "@nestjs/testing": "^11.1.19",
     "@supabase/supabase-js": "^2.105.4",
     "@swc/core": "^1.15.33",
+    "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
-    "eslint": "^10.0.2",
     "elysia": "^1.4.0",
+    "eslint": "^10.0.2",
     "h3": "2.0.1-rc.20",
     "hono": "^4.12.5",
     "prettier": "3.8.1",
@@ -144,6 +150,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "jose": "^6.2.0"
+    "jose": "^6.2.0",
+    "pg": "^8.21.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       jose:
         specifier: ^6.2.0
         version: 6.2.0
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.4.2
@@ -39,6 +42,9 @@ importers:
       '@swc/core':
         specifier: ^1.15.33
         version: 1.15.33
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/supertest':
         specifier: ^7.2.0
         version: 7.2.0
@@ -957,6 +963,9 @@ packages:
 
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -1944,6 +1953,40 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1964,6 +2007,22 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2470,6 +2529,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3205,6 +3268,12 @@ snapshots:
   '@types/node@25.3.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.3.0
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -4200,6 +4269,41 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
+  pg-protocol@1.14.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -4229,6 +4333,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -4748,6 +4862,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/src/gates/postgres/README.md
+++ b/src/gates/postgres/README.md
@@ -1,0 +1,123 @@
+# `@supabase/server/gates/postgres`
+
+Direct Postgres access from a handler, with Supabase's auth model intact. Two gates:
+
+- **`withPostgres`** — contributes `ctx.postgres`, an **RLS-scoped** client. Every
+  operation runs as the caller's JWT (claims + connection role pinned to a single
+  transaction, PostgREST-style), so `auth.uid()` and your RLS policies behave exactly
+  as they do through PostgREST.
+- **`withPostgresAdmin`** — contributes `ctx.postgresAdmin`, an **RLS-bypassing**
+  client for trusted server-side work that must see every row.
+
+> **Node/Deno only.** These gates use [`pg`](https://node-postgres.com) and do **not**
+> run on Cloudflare Workers / edge runtimes. The `pg` import is confined to this
+> subpath, so importing the package root (or any other subpath) stays edge-safe — only
+> `@supabase/server/gates/postgres` pulls in node-postgres.
+
+```ts
+import { withSupabase } from '@supabase/server'
+import {
+  withPostgres,
+  withPostgresAdmin,
+} from '@supabase/server/gates/postgres'
+
+export default {
+  fetch: withSupabase(
+    { auth: 'user' }, // ctx.supabase, ctx.jwtClaims
+    withPostgres(
+      {}, // ctx.postgres      — RLS as the user
+      withPostgresAdmin(
+        {}, // ctx.postgresAdmin — bypasses RLS
+        async (_req, ctx) => {
+          // auth.uid() = ctx.jwtClaims.sub
+          const mine = await ctx.postgres.query('select * from notes')
+          const all = await ctx.postgresAdmin.query(
+            'select count(*) from notes',
+          )
+
+          // Multi-statement atomicity when you want it:
+          await ctx.postgres.tx(async (c) => {
+            await c.query('insert into notes(body) values ($1)', ['a'])
+            await c.query('insert into notes(body) values ($1)', ['b'])
+          })
+
+          return Response.json({ mine: mine.rows, total: all.rows[0].count })
+        },
+      ),
+    ),
+  ),
+}
+```
+
+`withPostgres` declares `jwtClaims` as a prerequisite, so composing it **outside**
+`withSupabase` (or any wrapper that provides `jwtClaims`) is a compile-time type error.
+`withPostgresAdmin` has no prerequisites and can be used standalone.
+
+## Config
+
+Both gates take the same single optional field:
+
+| Field  | Type    | Description                                                                                                                                              |
+| ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pool` | `Pool?` | A `pg` `Pool` to draw connections from. When omitted, a lazily-created module-level pool backed by `SUPABASE_DB_URL` is used and shared across requests. |
+
+## `query` vs `tx`
+
+`ctx.postgres` / `ctx.postgresAdmin` each expose two methods:
+
+- **`query(text, params?)`** — run a single statement. For the user client, each call
+  is its **own** auth-scoped transaction; for the admin client it runs straight on the
+  pool.
+- **`tx(fn)`** — run a multi-statement block **atomically** in one transaction. The
+  whole block commits together, and throwing anywhere inside `fn` rolls all of it back.
+
+There is **no** implicit request-wide transaction. Two separate `query()` calls are two
+separate transactions — reach for `tx()` whenever statements must succeed or fail as a
+unit.
+
+```ts
+// One auth-scoped transaction; both inserts commit or neither does.
+await ctx.postgres.tx(async (c) => {
+  const { rows } = await c.query(
+    'insert into orders(total) values ($1) returning id',
+    [99],
+  )
+  await c.query('insert into order_items(order_id, sku) values ($1, $2)', [
+    rows[0].id,
+    'ABC',
+  ])
+})
+```
+
+## Role clamp
+
+`withPostgres` derives the user client's Postgres **connection role** from the JWT, but
+**clamps** it: `authenticated` only when `jwtClaims.role === 'authenticated'`, otherwise
+`anon`. A token claim can never flip the user client into `service_role` or any other
+RLS-bypassing role — bypassing RLS is exclusively `withPostgresAdmin`'s job. A `null`
+`jwtClaims` (non-user auth modes) runs as `anon`.
+
+## Pooling
+
+Every operation is a **self-contained short transaction**: open, `set local` the claims
+and role, do the work, commit, release. Nothing is held across the handler and no
+session-level (`is_local = false`) state is ever set on a pooled connection. That makes
+these gates safe through:
+
+- **Supavisor transaction mode** (port `6543`),
+- **Supavisor session mode**,
+- a **direct** connection.
+
+Point `SUPABASE_DB_URL` (or a `pool` you pass in) at whichever fits your deployment.
+
+## Testing
+
+The integration suite ([`index.test.ts`](./index.test.ts)) needs a real Postgres and
+self-skips unless `SUPABASE_DB_URL` is set. To run it locally:
+
+```sh
+SUPABASE_DB_URL='postgres://postgres:postgres@127.0.0.1:5432/postgres' pnpm test
+```
+
+The suite seeds its own roles, `auth.uid()`, and an RLS-protected table — point it at a
+throwaway database (a local `supabase start` stack or a disposable Postgres container).

--- a/src/gates/postgres/db.ts
+++ b/src/gates/postgres/db.ts
@@ -1,0 +1,133 @@
+/**
+ * Postgres client helpers for the {@link withPostgres} / {@link withPostgresAdmin}
+ * gates.
+ *
+ * The `pg` import lives here and nowhere else in the package — keep it that way
+ * so importing the package root (or any edge-targeted subpath) never pulls
+ * node-postgres into a Workers/edge bundle. This module runs only on Node/Deno
+ * server runtimes.
+ *
+ * Every operation owns its connection lifecycle: each {@link Db.query} runs in
+ * its own short transaction, and {@link Db.tx} wraps a multi-statement block in
+ * one. By the time a returned promise settles, the connection is already back
+ * in the pool — there is no connection held across the request handler, so the
+ * gate needs no after-handler cleanup hook.
+ */
+
+import { Pool, type PoolClient, type QueryResult } from 'pg'
+
+/**
+ * A minimal Postgres surface contributed at `ctx.postgres` / `ctx.postgresAdmin`.
+ *
+ * - `query` — run a single statement. For the user client this is its own
+ *   auth-scoped transaction; for the admin client it runs straight on the pool.
+ * - `tx` — run a multi-statement block atomically in one transaction. Throwing
+ *   inside `fn` rolls the whole block back.
+ */
+export interface Db {
+  /** Run a single parameterized statement and resolve its {@link QueryResult}. */
+  query: (text: string, params?: unknown[]) => Promise<QueryResult>
+
+  /** Run `fn` against a dedicated client inside one transaction, atomically. */
+  tx: <T>(fn: (client: PoolClient) => Promise<T>) => Promise<T>
+}
+
+/** Connection roles the user client may run as. Never `service_role`. */
+export type Role = 'authenticated' | 'anon'
+
+/** RFC 7519 claims subset the auth-scoped transaction injects into Postgres. */
+export type Claims = { sub?: string; role?: string; [k: string]: unknown }
+
+let defaultPool: Pool | undefined
+
+/** Read `SUPABASE_DB_URL` across Deno / Node / Bun, mirroring `resolveEnv`. */
+function dbUrl(): string | undefined {
+  if (typeof Deno !== 'undefined' && Deno.env?.get) {
+    return Deno.env.get('SUPABASE_DB_URL')
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.SUPABASE_DB_URL
+  }
+  return undefined
+}
+
+/**
+ * Resolve the pool to use: an explicit `override`, or a lazily-created module
+ * default backed by `SUPABASE_DB_URL`. The default is created once and reused
+ * across requests.
+ */
+export function getPool(override?: Pool): Pool {
+  if (override) return override
+  defaultPool ??= new Pool({ connectionString: dbUrl() })
+  return defaultPool
+}
+
+/**
+ * PostgREST-style auth-scoped transaction: open a transaction, pin the JWT
+ * claims and connection role to it with `set local` (so nothing leaks onto the
+ * pooled connection), run `fn`, then commit and release.
+ *
+ * Self-contained — by the time the returned promise settles, the connection is
+ * already back in the pool. No after-handler cleanup required.
+ */
+async function inAuthedTx<T>(
+  pool: Pool,
+  claims: Claims,
+  role: Role,
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect()
+  try {
+    await client.query('begin')
+    await client.query(`select set_config('request.jwt.claims', $1, true)`, [
+      JSON.stringify(claims),
+    ])
+    await client.query(`set local role ${role}`)
+    const out = await fn(client)
+    await client.query('commit')
+    return out
+  } catch (e) {
+    await client.query('rollback')
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+/**
+ * User client: each `query()` is its own auth-scoped transaction; `tx()` runs a
+ * multi-statement block atomically in one auth-scoped transaction. Both apply
+ * the caller's `claims` and `role`, so RLS policies see the authenticated user.
+ */
+export function authedDb(pool: Pool, claims: Claims, role: Role): Db {
+  return {
+    query: (text, params) =>
+      inAuthedTx(pool, claims, role, (c) => c.query(text, params)),
+    tx: (fn) => inAuthedTx(pool, claims, role, fn),
+  }
+}
+
+/**
+ * Admin client: bypasses RLS by staying as the connection role (no `set role`,
+ * no claims). `query()` runs straight on the pool; `tx()` is a plain
+ * begin/commit block.
+ */
+export function adminDb(pool: Pool): Db {
+  return {
+    query: (text, params) => pool.query(text, params),
+    async tx(fn) {
+      const client = await pool.connect()
+      try {
+        await client.query('begin')
+        const out = await fn(client)
+        await client.query('commit')
+        return out
+      } catch (e) {
+        await client.query('rollback')
+        throw e
+      } finally {
+        client.release()
+      }
+    },
+  }
+}

--- a/src/gates/postgres/index.test.ts
+++ b/src/gates/postgres/index.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration tests for the postgres gates. These need a REAL Postgres — RLS,
+ * roles, and `set local role` can't be faked by an in-memory shim — so the
+ * whole suite self-skips unless `SUPABASE_DB_URL` is set. Point it at a local
+ * Supabase stack (`supabase start`) or any Postgres where the connecting role
+ * is a superuser / has `BYPASSRLS` and can `set role authenticated`.
+ *
+ * `beforeAll` seeds everything the cases assume:
+ * - roles `authenticated`, `anon`, `service_role`, granted to the connecting
+ *   role so `set local role` works,
+ * - `auth.uid()` reading `request.jwt.claims ->> 'sub'`,
+ * - table `gate_pg_notes(id, owner uuid default auth.uid(), body)` with RLS on
+ *   and policy `owner = auth.uid()`.
+ *
+ * The `@ts-expect-error` case below is validated by `tsc --noEmit` even in CI,
+ * where the runtime cases are skipped.
+ */
+
+import { Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { JWTClaims } from '../../types.js'
+
+import { withPostgres } from './with-postgres.js'
+import { withPostgresAdmin } from './with-postgres-admin.js'
+
+const DB_URL =
+  typeof process !== 'undefined' ? process.env.SUPABASE_DB_URL : undefined
+
+const USER_A = '11111111-1111-1111-1111-111111111111'
+const USER_B = '22222222-2222-2222-2222-222222222222'
+
+const SETUP_SQL = `
+  create schema if not exists auth;
+
+  create or replace function auth.uid() returns uuid language sql stable as $$
+    select nullif(current_setting('request.jwt.claims', true)::jsonb ->> 'sub', '')::uuid
+  $$;
+
+  do $$ begin
+    if not exists (select from pg_roles where rolname = 'authenticated') then create role authenticated; end if;
+    if not exists (select from pg_roles where rolname = 'anon') then create role anon; end if;
+    if not exists (select from pg_roles where rolname = 'service_role') then create role service_role; end if;
+  end $$;
+
+  grant authenticated, anon, service_role to current_user;
+
+  drop table if exists gate_pg_notes;
+  create table gate_pg_notes (
+    id uuid primary key default gen_random_uuid(),
+    owner uuid not null default auth.uid(),
+    body text
+  );
+  alter table gate_pg_notes enable row level security;
+  grant select, insert, update, delete on gate_pg_notes to authenticated, anon;
+  create policy gate_pg_notes_owner on gate_pg_notes
+    using (owner = auth.uid()) with check (owner = auth.uid());
+`
+
+const TEARDOWN_SQL = `drop table if exists gate_pg_notes;`
+
+/** Build a minimal authenticated-user upstream ctx for the gate. */
+function authedCtx(sub: string): { jwtClaims: JWTClaims } {
+  return { jwtClaims: { sub, role: 'authenticated' } }
+}
+
+const req = (): Request => new Request('http://localhost/')
+
+describe.skipIf(!DB_URL)('postgres gates (integration)', () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL })
+    await pool.query(SETUP_SQL)
+    // Seed as admin (bypasses RLS) with explicit owners: two for A, one for B.
+    await pool.query(
+      `insert into gate_pg_notes (owner, body) values ($1, 'a1'), ($1, 'a2'), ($2, 'b1')`,
+      [USER_A, USER_B],
+    )
+  })
+
+  afterAll(async () => {
+    if (!pool) return
+    await pool.query(TEARDOWN_SQL)
+    await pool.end()
+  })
+
+  it('scopes ctx.postgres.query to the caller — other users rows are invisible', async () => {
+    const handler = withPostgres({ pool }, async (_req, ctx) => {
+      const r = await ctx.postgres.query(
+        'select body from gate_pg_notes order by body',
+      )
+      return Response.json({ bodies: r.rows.map((row) => row.body) })
+    })
+
+    const res = await handler(req(), authedCtx(USER_A))
+    expect(await res.json()).toEqual({ bodies: ['a1', 'a2'] })
+  })
+
+  it('ctx.postgres.tx commits a multi-statement block atomically', async () => {
+    const handler = withPostgres({ pool }, async (_req, ctx) => {
+      await ctx.postgres.tx(async (c) => {
+        await c.query(`insert into gate_pg_notes (body) values ('tx1')`)
+        await c.query(`insert into gate_pg_notes (body) values ('tx2')`)
+      })
+      const r = await ctx.postgres.query(
+        `select count(*)::int as n from gate_pg_notes where body in ('tx1', 'tx2')`,
+      )
+      return Response.json({ n: r.rows[0].n })
+    })
+
+    const res = await handler(req(), authedCtx(USER_A))
+    expect(await res.json()).toEqual({ n: 2 })
+  })
+
+  it('ctx.postgres.tx rolls the whole block back when fn throws', async () => {
+    const handler = withPostgres({ pool }, async (_req, ctx) => {
+      try {
+        await ctx.postgres.tx(async (c) => {
+          await c.query(
+            `insert into gate_pg_notes (body) values ('rollback-me')`,
+          )
+          throw new Error('boom')
+        })
+      } catch {
+        // expected
+      }
+      const r = await ctx.postgres.query(
+        `select count(*)::int as n from gate_pg_notes where body = 'rollback-me'`,
+      )
+      return Response.json({ n: r.rows[0].n })
+    })
+
+    const res = await handler(req(), authedCtx(USER_A))
+    expect(await res.json()).toEqual({ n: 0 })
+  })
+
+  it('ctx.postgresAdmin.query bypasses RLS and sees every row', async () => {
+    const handler = withPostgresAdmin({ pool }, async (_req, ctx) => {
+      const r = await ctx.postgresAdmin.query(
+        `select count(*)::int as n from gate_pg_notes where body in ('a1', 'a2', 'b1')`,
+      )
+      return Response.json({ n: r.rows[0].n })
+    })
+
+    const res = await handler(req())
+    expect(await res.json()).toEqual({ n: 3 })
+  })
+
+  it('null jwtClaims runs as anon — owner-scoped policy yields no rows', async () => {
+    const handler = withPostgres({ pool }, async (_req, ctx) => {
+      const r = await ctx.postgres.query(
+        'select count(*)::int as n from gate_pg_notes',
+      )
+      return Response.json({ n: r.rows[0].n })
+    })
+
+    const res = await handler(req(), { jwtClaims: null })
+    expect(await res.json()).toEqual({ n: 0 })
+  })
+
+  it('does not leak connections — pool returns to baseline after N requests', async () => {
+    const handler = withPostgres({ pool }, async (_req, ctx) => {
+      await ctx.postgres.query('select 1')
+      return Response.json({ ok: true })
+    })
+
+    for (let i = 0; i < 10; i++) {
+      await handler(req(), authedCtx(USER_A))
+    }
+
+    // Every checked-out client has been released back to the pool, none left
+    // mid-transaction.
+    expect(pool.idleCount).toBe(pool.totalCount)
+    expect(pool.waitingCount).toBe(0)
+  })
+
+  it('rejects composing withPostgres without an upstream jwtClaims (compile-fail)', () => {
+    const handler = withPostgres({ pool }, async (_req, ctx) => {
+      void ctx.postgres
+      return Response.json({ ok: true })
+    })
+    // `withPostgres` declares `In = { jwtClaims }`, so `baseCtx` is required —
+    // invoking without it is a type error. Type-checked but never executed, so
+    // it can't trip a runtime rejection.
+    const compileFail = (): unknown =>
+      // @ts-expect-error — missing required baseCtx providing jwtClaims
+      handler(req())
+    void compileFail
+  })
+})

--- a/src/gates/postgres/index.ts
+++ b/src/gates/postgres/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Postgres gates.
+ *
+ * Node/Deno-only — these gates use `pg` and do not run on Workers/edge.
+ *
+ * @packageDocumentation
+ */
+
+export { withPostgres } from './with-postgres.js'
+export type { PostgresConfig } from './with-postgres.js'
+export { withPostgresAdmin } from './with-postgres-admin.js'
+export type { PostgresAdminConfig } from './with-postgres-admin.js'
+export type { Db } from './db.js'

--- a/src/gates/postgres/with-postgres-admin.ts
+++ b/src/gates/postgres/with-postgres-admin.ts
@@ -1,0 +1,52 @@
+/**
+ * `withPostgresAdmin` — injects an RLS-bypassing Postgres client at
+ * `ctx.postgresAdmin`.
+ *
+ * The client stays as the connection role and sets no JWT claims, so RLS does
+ * not apply. It has no upstream prerequisites — use it for trusted, server-side
+ * work that must see every row. The `pg` import is confined to this subpath; it
+ * runs only on Node/Deno, not Workers/edge.
+ */
+
+import type { Pool } from 'pg'
+
+import { defineGate, type Gate } from '../../core/gates/index.js'
+
+import { type Db, getPool, adminDb } from './db.js'
+
+/** Per-instance configuration for `withPostgresAdmin(config, handler)`. */
+export interface PostgresAdminConfig {
+  /**
+   * Pool to draw connections from. When omitted, a lazily-created module-level
+   * pool backed by `SUPABASE_DB_URL` is used (shared across requests).
+   */
+  pool?: Pool
+}
+
+/**
+ * Postgres admin gate — contributes an RLS-bypassing {@link Db} at
+ * `ctx.postgresAdmin`.
+ *
+ * @example
+ * ```ts
+ * import { withPostgresAdmin } from '@supabase/server/gates/postgres'
+ *
+ * export default {
+ *   fetch: withPostgresAdmin({}, async (_req, ctx) => {
+ *     const all = await ctx.postgresAdmin.query('select count(*) from notes')
+ *     return Response.json({ total: all.rows[0].count })
+ *   }),
+ * }
+ * ```
+ */
+export const withPostgresAdmin: Gate<
+  'postgresAdmin',
+  PostgresAdminConfig,
+  Record<never, never>,
+  Db
+> = defineGate<'postgresAdmin', PostgresAdminConfig, Record<never, never>, Db>({
+  key: 'postgresAdmin',
+  run: (config) => async () => ({
+    postgresAdmin: adminDb(getPool(config.pool)),
+  }),
+})

--- a/src/gates/postgres/with-postgres.ts
+++ b/src/gates/postgres/with-postgres.ts
@@ -1,0 +1,71 @@
+/**
+ * `withPostgres` — injects an RLS-scoped Postgres client at `ctx.postgres`.
+ *
+ * Each operation runs as the caller's JWT (claims + connection role pinned to a
+ * single transaction, PostgREST-style), so `auth.uid()` and RLS policies behave
+ * exactly as they do through PostgREST. Use it when you need raw SQL but still
+ * want Supabase's auth model.
+ *
+ * Requires an upstream gate to provide `jwtClaims` (e.g. `withSupabase`) — the
+ * `In` shape makes composing it standalone a type error. The `pg` import is
+ * confined to this subpath; it runs only on Node/Deno, not Workers/edge.
+ */
+
+import type { Pool } from 'pg'
+
+import { defineGate, type Gate } from '../../core/gates/index.js'
+import type { JWTClaims } from '../../types.js'
+
+import { type Db, type Role, getPool, authedDb } from './db.js'
+
+/** Per-instance configuration for `withPostgres(config, handler)`. */
+export interface PostgresConfig {
+  /**
+   * Pool to draw connections from. When omitted, a lazily-created module-level
+   * pool backed by `SUPABASE_DB_URL` is used (shared across requests).
+   */
+  pool?: Pool
+}
+
+/**
+ * Clamp the *connection role* to `authenticated` / `anon` — never let a token
+ * claim flip the user client into an RLS-bypassing role. `service_role` belongs
+ * to {@link withPostgresAdmin}, not here.
+ */
+function userRole(claims: JWTClaims | null): Role {
+  return claims?.role === 'authenticated' ? 'authenticated' : 'anon'
+}
+
+/**
+ * Postgres gate — contributes an RLS-scoped {@link Db} at `ctx.postgres`.
+ *
+ * @example
+ * ```ts
+ * import { withSupabase } from '@supabase/server'
+ * import { withPostgres } from '@supabase/server/gates/postgres'
+ *
+ * export default {
+ *   fetch: withSupabase({ auth: 'user' },
+ *     withPostgres({}, async (_req, ctx) => {
+ *       // auth.uid() = ctx.jwtClaims.sub; RLS applies
+ *       const mine = await ctx.postgres.query('select * from notes')
+ *       return Response.json({ notes: mine.rows })
+ *     })),
+ * }
+ * ```
+ */
+export const withPostgres: Gate<
+  'postgres',
+  PostgresConfig,
+  { jwtClaims: JWTClaims | null },
+  Db
+> = defineGate<'postgres', PostgresConfig, { jwtClaims: JWTClaims | null }, Db>(
+  {
+    key: 'postgres',
+    run: (config) => async (_req, ctx) => {
+      const pool = getPool(config.pool)
+      const claims = ctx.jwtClaims ?? { role: 'anon' }
+      return { postgres: authedDb(pool, claims, userRole(ctx.jwtClaims)) }
+    },
+  },
+)

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/core/adapters/index.ts',
     'src/gates/auth-hook/index.ts',
     'src/gates/feature-flag/index.ts',
+    'src/gates/postgres/index.ts',
     'src/adapters/hono/index.ts',
     'src/adapters/h3/index.ts',
     'src/adapters/elysia/index.ts',


### PR DESCRIPTION
Adds a `postgres` gate pair at the `@supabase/server/gates/postgres` subpath — direct Postgres access from a handler while keeping Supabase's auth model.

## What's added
- **`withPostgres`** → `ctx.postgres`: RLS-scoped `pg` client. Each operation runs as the caller's JWT (claims + connection role pinned to a single transaction, PostgREST-style), so `auth.uid()` and RLS policies behave exactly as through PostgREST. Requires upstream `jwtClaims` (composing it outside `withSupabase` is a compile-time error).
- **`withPostgresAdmin`** → `ctx.postgresAdmin`: RLS-bypassing client. No prerequisites.
- Each client exposes `query(text, params?)` (its own auth-scoped transaction) and `tx(fn)` (multi-statement atomicity). No implicit request-wide transaction; every operation is a self-contained short transaction, so no after-handler cleanup hook is needed.

## Notes for review
- **First runtime-specific gate.** Uses `pg` (node-postgres) → the subpath is **Node/Deno-only**, not Workers/edge. The `pg` import is confined to this module; verified the package root never pulls `pg` into its bundle.
- `pg` added to `dependencies`, `@types/pg` to `devDependencies`.
- **Role clamp:** the user client's connection role is clamped to `authenticated`/`anon` and can never be flipped to `service_role` by a token claim — RLS bypass is exclusively `withPostgresAdmin`'s job.

## Testing
- Integration suite (`index.test.ts`) self-skips unless `SUPABASE_DB_URL` is set; the `@ts-expect-error` compile-fail assertion runs in CI via typecheck regardless. Validated against a real Postgres 16 container: RLS scoping, cross-user isolation, tx commit/rollback, admin RLS-bypass, anon role for null claims, connection-leak baseline.
- Also exercised end-to-end as a real Supabase Edge Function (user / anon-via-secret / no-credential paths).
- `pnpm typecheck`, `lint`, `test`, and the JSR slow-type check are clean (gate exports carry explicit `Gate<…>` annotations).

Stacks on `FUNC-577/gates-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)