### PR TITLE
docs: replace manual type-assertioin when using the Hono adapter

### DIFF
--- a/docs/typescript-generics.md
+++ b/docs/typescript-generics.md
@@ -76,7 +76,7 @@ const { data: users } = await supabaseAdmin.from('profiles').select()
 
 ## Using with the Hono adapter
 
-The Hono context variable is typed as `SupabaseContext` (without the generic). To get typed clients, assert the type when destructuring:
+Pass an app environment type to `Hono<Env>()` so Hono knows the `supabaseContext` variable includes your generated database types:
 
 ```ts
 import { Hono } from 'hono'
@@ -84,12 +84,18 @@ import { withSupabase } from '@supabase/server/adapters/hono'
 import type { SupabaseContext } from '@supabase/server'
 import type { Database } from './database.types.ts'
 
-const app = new Hono()
+type Env = {
+  Variables: {
+    supabaseContext: SupabaseContext<Database>
+  }
+}
+
+const app = new Hono<Env>()
 
 app.use('*', withSupabase({ auth: 'user' }))
 
 app.get('/todos', async (c) => {
-  const { supabase } = c.var.supabaseContext as SupabaseContext<Database>
+  const { supabase } = c.var.supabaseContext
   const { data } = await supabase.from('todos').select('id, title')
   return c.json(data)
 })

--- a/src/adapters/hono/middleware.test.ts
+++ b/src/adapters/hono/middleware.test.ts
@@ -1,10 +1,33 @@
 import { Hono } from 'hono'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import type { SupabaseContext } from '../../types.js'
 import { withSupabase } from './middleware.js'
 
 type Env = { Variables: { supabaseContext: SupabaseContext } }
+
+type Database = {
+  public: {
+    Tables: {
+      todos: {
+        Row: { id: number; title: string }
+        Insert: { id?: number; title: string }
+        Update: { id?: number; title?: string }
+        Relationships: []
+      }
+    }
+    Views: {}
+    Functions: {}
+    Enums: {}
+    CompositeTypes: {}
+  }
+}
+
+type TypedEnv = {
+  Variables: {
+    supabaseContext: SupabaseContext<Database>
+  }
+}
 
 describe('hono supabase middleware', () => {
   const env = {
@@ -32,6 +55,18 @@ describe('hono supabase middleware', () => {
     expect(body.authMode).toBe('none')
     expect(body.hasSupabase).toBe(true)
     expect(body.hasAdmin).toBe(true)
+  })
+
+  it('uses the Hono app env to type the Supabase context', async () => {
+    const app = new Hono<TypedEnv>()
+    app.use('*', withSupabase({ auth: 'none', env }))
+    app.get('/', (c) => {
+      const ctx = c.get('supabaseContext')
+      expectTypeOf(ctx).toEqualTypeOf<SupabaseContext<Database>>()
+      return c.json({ authMode: ctx.authMode })
+    })
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
   })
 
   it('throws HTTPException on auth failure', async () => {

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -18,8 +18,15 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * ```ts
  * import { Hono } from 'hono'
  * import { withSupabase } from '@supabase/server/adapters/hono'
+ * import type { SupabaseContext } from '@supabase/server'
  *
- * const app = new Hono()
+ * type Env = {
+ *   Variables: {
+ *     supabaseContext: SupabaseContext
+ *   }
+ * }
+ *
+ * const app = new Hono<Env>()
  * app.use('*', withSupabase({ auth: 'user' }))
  *
  * app.get('/profile', async (c) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Better way to add database types to the SupabaseContext in the Hono adapter

## What is the current behavior?

Developers are expected to manually assert the `SupabaseContext` each time they access it in a request

## What is the new behavior?

Developers apply the `SupabaseContext<Database>` once when they call `new Hono()