### PR TITLE
docs: refresh stale auth-API references in JSDoc

### DIFF
--- a/src/adapters/elysia/plugin.ts
+++ b/src/adapters/elysia/plugin.ts
@@ -29,7 +29,7 @@ export class SupabaseError extends Error {
  * import { withSupabase } from '@supabase/server/adapters/elysia'
  *
  * const app = new Elysia()
- *   .use(withSupabase({ allow: 'user' }))
+ *   .use(withSupabase({ auth: 'user' }))
  *   .get('/games', async ({ supabaseContext }) => {
  *     const { data } = await supabaseContext.supabase.from('favorite_games').select()
  *     return data
@@ -47,7 +47,7 @@ export class SupabaseError extends Error {
  *   .get('/health', () => ({ status: 'ok' }))
  *   .group('/api', (app) =>
  *     app
- *       .use(withSupabase({ allow: 'user' }))
+ *       .use(withSupabase({ auth: 'user' }))
  *       .get('/profile', async ({ supabaseContext }) => {
  *         return supabaseContext.userClaims
  *       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,7 @@ export interface Credentials {
  * Result of credential verification.
  *
  * Contains the resolved auth mode, the verified token (for `"user"` mode),
- * decoded JWT claims, and the matched key name (for `"public"` / `"secret"` modes).
+ * decoded JWT claims, and the matched key name (for `"publishable"` / `"secret"` modes).
  *
  * @see {@link verifyCredentials}
  * @see {@link verifyAuth}
@@ -150,7 +150,7 @@ export interface AuthResult {
   /** Raw JWT payload, or `null` when no JWT is present. */
   jwtClaims: JWTClaims | null
 
-  /** Name of the matched key (e.g. `"default"`, `"mobile"`), or `null` for `"user"` / `"always"` modes. */
+  /** Name of the matched key (e.g. `"default"`, `"mobile"`), or `null` for `"user"` / `"none"` modes. */
   keyName?: string | null
 }
 


### PR DESCRIPTION
## What

The `allow`→`auth` / `'always'`→`'none'` / `'public'`→`'publishable'` / `authType`→`authMode` rename (landed in #48) was already applied across the prose docs and `SKILL.md`, but a few JSDoc reference comments — which feed the typedoc-generated API reference — still used the old names.

## Changes

- `src/types.ts` — `AuthResult` doc: `"public"` → `"publishable"`; `keyName` doc: `"always"` → `"none"`
- `src/adapters/elysia/plugin.ts` — both `@example` blocks: `allow: 'user'` → `auth: 'user'`

## Not touched (intentional)

- Deprecation-coverage tests (`verify-credentials.test.ts`, `with-supabase.test.ts`) that exercise the legacy `allow` option on purpose
- The `allow` backward-compat wiring (`create-supabase-context.ts`, `deprecation.ts`) and `MIGRATION.md`

JSDoc-comment-only edits — no compilation impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)