### PR TITLE
fix(test): correct sub claim in remote JWKS token fixture and wire tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,7 @@ jobs:
 
       - run: pnpm lint
 
+      - run: pnpm test
+
       - name: Verify JSR packaging
         run: pnpm dlx jsr@0.14.3 publish --dry-run --allow-dirty

--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -408,7 +408,7 @@ describe('verifyCredentials', () => {
         kid: string,
       ) =>
         await new SignJWT({
-          sub: 'user-123',
+          sub: 'user-remote',
           role: 'authenticated',
           email: 'test@example.com',
         })


### PR DESCRIPTION
Tokens in the remote JWKS describe block were minted with sub 'user-123' but two tests asserted 'user-remote'. The implementation was correct, the fixture was wrong.

Also adds `pnpm test` to ci.yml — tests were never running in CI.