### PR TITLE
chore: add group sdk as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global owners for the entire repository
-* @supabase/server-dx @supabase/edge-functions @supabase/admin @supabase/security
+* @supabase/server-dx @supabase/edge-functions @supabase/admin @supabase/security @supabase/sdk


### PR DESCRIPTION
Add `sdk` team as codeowners