### PR TITLE
refactor: replace custom JsonWebKeySet with JSONWebKeySet

### DIFF
--- a/src/core/resolve-env.test.ts
+++ b/src/core/resolve-env.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveEnv } from './resolve-env.js'
 import { MissingSupabaseURLError } from '../errors.js'
-import type { JsonWebKeySet } from '../types.js'
+import type { JSONWebKeySet } from 'jose'
 
 describe('resolveEnv', () => {
   afterEach(() => {
@@ -244,7 +244,7 @@ describe('resolveEnv', () => {
       default: 'sb_secret_fake_default_key_val',
       internal: 'sb_secret_fake_internal_key',
     })
-    const jwks = result.data!.jwks as JsonWebKeySet
+    const jwks = result.data!.jwks as JSONWebKeySet
     expect(jwks.keys).toHaveLength(2)
     expect((jwks.keys[0] as Record<string, unknown>).kid).toBe(
       'cb770052-bdd3-4f5e-8d6f-8836046b7c93',

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -1,5 +1,7 @@
 import { EnvError, Errors, MissingSupabaseURLError } from '../errors.js'
-import type { JsonWebKeySet, SupabaseEnv } from '../types.js'
+import type { JSONWebKeySet } from 'jose'
+
+import type { SupabaseEnv } from '../types.js'
 
 /**
  * Reads an environment variable from the current runtime (Deno, Node.js, or Bun).
@@ -64,13 +66,13 @@ function resolveKeys(
  *
  * @internal
  */
-function parseJwks(raw: string | undefined): JsonWebKeySet | null {
+function parseJwks(raw: string | undefined): JSONWebKeySet | null {
   if (!raw) return null
   try {
     const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) return { keys: parsed }
     if (parsed?.keys && Array.isArray(parsed.keys))
-      return parsed as JsonWebKeySet
+      return parsed as JSONWebKeySet
     return null
   } catch {
     return null
@@ -124,7 +126,7 @@ function parseJwksUrl(raw: string | undefined): URL | null {
  *
  * @internal
  */
-function resolveJwks(): JsonWebKeySet | URL | null {
+function resolveJwks(): JSONWebKeySet | URL | null {
   const rawJwks = getEnvVar('SUPABASE_JWKS')
   if (rawJwks && rawJwks.trim()) {
     return parseJwks(rawJwks)

--- a/src/core/verify-credentials.test.ts
+++ b/src/core/verify-credentials.test.ts
@@ -9,7 +9,9 @@ import {
   vi,
 } from 'vitest'
 
-import type { Credentials, JsonWebKeySet, SupabaseEnv } from '../types.js'
+import type { JSONWebKeySet } from 'jose'
+
+import type { Credentials, SupabaseEnv } from '../types.js'
 import { verifyCredentials } from './verify-credentials.js'
 import { _resetAllowDeprecationWarned } from './utils/deprecation.js'
 import { InvalidCredentialsError } from '../errors.js'
@@ -276,7 +278,7 @@ describe('verifyCredentials', () => {
   })
 
   describe('user mode', () => {
-    let jwks: JsonWebKeySet
+    let jwks: JSONWebKeySet
     let validTokens: string[]
 
     beforeAll(async () => {
@@ -380,7 +382,7 @@ describe('verifyCredentials', () => {
   })
 
   describe('user mode with remote JWKS URL', () => {
-    let jwks: JsonWebKeySet
+    let jwks: JSONWebKeySet
     let validTokens: string[]
     let fetchMock: ReturnType<typeof vi.fn>
 
@@ -516,7 +518,7 @@ describe('verifyCredentials', () => {
       publicJwkB.alg = 'RS256'
       publicJwkB.use = 'sig'
       publicJwkB.kid = 'remote-key-b'
-      const jwksB: JsonWebKeySet = { keys: [publicJwkB] }
+      const jwksB: JSONWebKeySet = { keys: [publicJwkB] }
       const tokenB = await new SignJWT({
         sub: 'user-remote-b',
         role: 'authenticated',
@@ -628,7 +630,7 @@ describe('verifyCredentials', () => {
   })
 
   describe('invalid credential rejection (no silent fallthrough)', () => {
-    let jwks: JsonWebKeySet
+    let jwks: JSONWebKeySet
 
     beforeAll(async () => {
       const { publicKey } = await generateKeyPair('RS256')

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -15,7 +15,6 @@ import type {
   AuthModeWithKey,
   AuthResult,
   Credentials,
-  JsonWebKeySet,
   JWTClaims,
   SupabaseEnv,
   UserClaims,
@@ -111,7 +110,7 @@ let remoteJwksResolver: { url: string; resolver: JwksResolver } | undefined =
  *
  * @internal
  */
-function getJwksResolver(jwks: JsonWebKeySet | URL): JwksResolver {
+function getJwksResolver(jwks: JSONWebKeySet | URL): JwksResolver {
   if (jwks instanceof URL) {
     const url = jwks.toString()
     if (remoteJwksResolver?.url !== url) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,11 @@
+import type { JSONWebKeySet } from 'jose'
+
 import type {
   SupabaseClient,
   SupabaseClientOptions,
 } from '@supabase/supabase-js'
+
+export type { JSONWebKeySet }
 
 /**
  * Authentication mode that determines what credentials a request must provide.
@@ -100,17 +104,7 @@ export interface SupabaseEnv {
    * Each env var is authoritative when set: a malformed value resolves to
    * `null` rather than falling through to the other variable.
    */
-  jwks: JsonWebKeySet | URL | null
-}
-
-/**
- * A JSON Web Key Set as defined by RFC 7517.
- *
- * @see https://datatracker.ietf.org/doc/html/rfc7517
- */
-export interface JsonWebKeySet {
-  /** Array of JSON Web Keys. */
-  keys: JsonWebKey[]
+  jwks: JSONWebKeySet | URL | null
 }
 
 /**


### PR DESCRIPTION
The custom JsonWebKeySet type used the browser's built-in JsonWebKey[] which lacks standard JWK fields like kid. Jose's JSONWebKeySet uses JWK[] which is a proper superset. No public API change, the type was internal.