### PR TITLE
fix: add ./peer/supabase-js to jsr.json exports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -121,7 +122,6 @@ jobs:
 
       - name: Publish to JSR
         if: ${{ steps.version.outputs.skip != 'true' }}
-        continue-on-error: true
         run: npx jsr@0.14.3 publish --allow-dirty
 
       - name: Create GitHub pre-release

--- a/jsr.json
+++ b/jsr.json
@@ -4,20 +4,14 @@
   "exports": {
     ".": "./src/index.ts",
     "./core": "./src/core/index.ts",
+    "./peer/supabase-js": "./src/peer/supabase-js/index.ts",
     "./adapters/hono": "./src/adapters/hono/index.ts",
     "./adapters/h3": "./src/adapters/h3/index.ts",
     "./adapters/elysia": "./src/adapters/elysia/index.ts",
     "./adapters/nestjs": "./src/adapters/nestjs/index.ts"
   },
   "publish": {
-    "include": [
-      "src/**/*.ts",
-      "README.md",
-      "LICENSE"
-    ],
-    "exclude": [
-      "src/**/*.test.ts",
-      "src/**/*.spec.ts"
-    ]
+    "include": ["src/**/*.ts", "README.md", "LICENSE"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
   }
 }


### PR DESCRIPTION
Two fixes to unblock JSR publishing and improve the JSR score.

**`jsr.json`** — `./peer/supabase-js` was present in `package.json` exports but missing from `jsr.json`, so the entrypoint was invisible to the JSR registry. Added it to keep both export maps in sync.

**`release.yml`** — JSR has been silently failing to publish since v1.0.0. PR #62 split the release workflow into two jobs to isolate npm's OIDC token from the `pnpm install` step (supply chain hardening after the TanStack/router incident). As part of that split, `id-token: write` was removed from the `build` job on the assumption that JSR uses a separate OIDC binding that does not require it. That assumption was wrong: JSR authenticates CI publishes via `Authorization: githuboidc <token>`, and the JSR CLI obtains that token from GitHub's OIDC endpoint — which GitHub only exposes when the job has `id-token: write`. The audience is JSR-scoped (not npm), so restoring `id-token: write` to the `build` job does not re-open the npm supply chain path. The `publish-npm` job remains isolated with no `pnpm install`. Also removes `continue-on-error: true` from the JSR publish step so future failures are visible.