### PR TITLE
docs: add @category tags to public API to prep for supabase docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## [1.2.0](https://github.com/supabase/server/compare/server-v1.1.0...server-v1.2.0) (2026-06-17)
 
-
 ### Features
 
-* add NestJS adapter ([#55](https://github.com/supabase/server/issues/55)) ([3052a6b](https://github.com/supabase/server/commit/3052a6b30931f0478bfc4f9dcd25505292b585a9))
-* add support for `HS256` JWKs ([#83](https://github.com/supabase/server/issues/83)) ([67c840d](https://github.com/supabase/server/commit/67c840dc5e8df9374877ca94dc6b6e278e4b13f9))
-
+- add NestJS adapter ([#55](https://github.com/supabase/server/issues/55)) ([3052a6b](https://github.com/supabase/server/commit/3052a6b30931f0478bfc4f9dcd25505292b585a9))
+- add support for `HS256` JWKs ([#83](https://github.com/supabase/server/issues/83)) ([67c840d](https://github.com/supabase/server/commit/67c840dc5e8df9374877ca94dc6b6e278e4b13f9))
 
 ### Bug Fixes
 
-* **docs:** Replace manual context casting with Hono Env type ([#77](https://github.com/supabase/server/issues/77)) ([5ac7ccf](https://github.com/supabase/server/commit/5ac7ccf629c246164659b8c1dc329c3e3066ff14))
-* **test:** lint regression in hono tests ([#79](https://github.com/supabase/server/issues/79)) ([182412b](https://github.com/supabase/server/commit/182412b2f0586fa942a6b6d2662fddf0776da9cf))
+- **docs:** Replace manual context casting with Hono Env type ([#77](https://github.com/supabase/server/issues/77)) ([5ac7ccf](https://github.com/supabase/server/commit/5ac7ccf629c246164659b8c1dc329c3e3066ff14))
+- **test:** lint regression in hono tests ([#79](https://github.com/supabase/server/issues/79)) ([182412b](https://github.com/supabase/server/commit/182412b2f0586fa942a6b6d2662fddf0776da9cf))
 
 ## [1.1.0](https://github.com/supabase/server/compare/server-v1.0.0...server-v1.1.0) (2026-05-19)
 

--- a/src/adapters/elysia/index.ts
+++ b/src/adapters/elysia/index.ts
@@ -1,6 +1,7 @@
 /**
  * Elysia framework adapter for `@supabase/server`.
  *
+ * @module
  * @packageDocumentation
  */
 

--- a/src/adapters/elysia/plugin.ts
+++ b/src/adapters/elysia/plugin.ts
@@ -31,7 +31,7 @@ export class SupabaseError extends Error {
  * @param config - Auth modes and optional environment overrides. CORS is excluded — use Elysia's CORS utilities.
  * @returns An Elysia plugin that exposes `supabaseContext`.
  *
- * @example App-wide auth via `.use()`
+ * @example App-wide auth via .use()
  * ```ts
  * import { Elysia } from 'elysia'
  * import { withSupabase } from '@supabase/server/adapters/elysia'
@@ -46,7 +46,7 @@ export class SupabaseError extends Error {
  * app.listen(3000)
  * ```
  *
- * @example Per-route auth via scoped `.use()`
+ * @example Per-route auth via scoped .use()
  * ```ts
  * import { Elysia } from 'elysia'
  * import { withSupabase } from '@supabase/server/adapters/elysia'

--- a/src/adapters/elysia/plugin.ts
+++ b/src/adapters/elysia/plugin.ts
@@ -4,6 +4,14 @@ import { createSupabaseContext } from '../../create-supabase-context.js'
 import type { AuthError } from '../../errors.js'
 import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
 
+/**
+ * Wraps an {@link AuthError} as an Elysia-compatible error.
+ *
+ * Discriminate in `onError` via `code === 'SupabaseError'`. The original
+ * `AuthError` is available as the typed `.cause`.
+ *
+ * @category Adapters
+ */
 export class SupabaseError extends Error {
   status: number
   declare cause: AuthError
@@ -55,6 +63,8 @@ export class SupabaseError extends Error {
  *
  * app.listen(3000)
  * ```
+ *
+ * @category Adapters
  */
 // The explicit return type below mirrors Elysia's own generic defaults, which use
 // `{}` literals — switching to `object` or `Record<string, never>` would not satisfy

--- a/src/adapters/h3/index.ts
+++ b/src/adapters/h3/index.ts
@@ -1,6 +1,7 @@
 /**
  * H3 framework adapter for `@supabase/server`.
  *
+ * @module
  * @packageDocumentation
  */
 

--- a/src/adapters/h3/middleware.ts
+++ b/src/adapters/h3/middleware.ts
@@ -42,6 +42,8 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  *   },
  * })
  * ```
+ *
+ * @category Adapters
  */
 export function withSupabase(
   config?: Omit<WithSupabaseConfig, 'cors'>,

--- a/src/adapters/h3/middleware.ts
+++ b/src/adapters/h3/middleware.ts
@@ -13,7 +13,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * @param config - Auth modes and optional environment overrides. CORS is excluded — use H3's CORS utilities.
  * @returns An H3 middleware.
  *
- * @example App-wide auth via `app.use()`
+ * @example App-wide auth via app.use()
  * ```ts
  * import { H3 } from 'h3'
  * import { withSupabase } from '@supabase/server/adapters/h3'
@@ -29,7 +29,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  * export default { fetch: app.fetch }
  * ```
  *
- * @example Per-route auth via `defineHandler`
+ * @example Per-route auth via defineHandler
  * ```ts
  * import { defineHandler } from 'h3'
  * import { withSupabase } from '@supabase/server/adapters/h3'

--- a/src/adapters/hono/index.ts
+++ b/src/adapters/hono/index.ts
@@ -1,6 +1,7 @@
 /**
  * Hono framework adapter for `@supabase/server`.
  *
+ * @module
  * @packageDocumentation
  */
 

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -37,6 +37,8 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  *
  * export default { fetch: app.fetch }
  * ```
+ *
+ * @category Adapters
  */
 export function withSupabase(
   config?: Omit<WithSupabaseConfig, 'cors'>,

--- a/src/adapters/nestjs/decorator.ts
+++ b/src/adapters/nestjs/decorator.ts
@@ -32,6 +32,8 @@ import type { SupabaseContext } from '../../types.js'
  *   }
  * }
  * ```
+ *
+ * @category Adapters
  */
 export const SupabaseCtx: (
   data?: keyof SupabaseContext,

--- a/src/adapters/nestjs/index.ts
+++ b/src/adapters/nestjs/index.ts
@@ -1,6 +1,7 @@
 /**
  * NestJS framework adapter for `@supabase/server`.
  *
+ * @module
  * @packageDocumentation
  */
 

--- a/src/adapters/nestjs/middleware.ts
+++ b/src/adapters/nestjs/middleware.ts
@@ -81,6 +81,8 @@ function toWebRequest(req: NestRequestLike): Request {
  *   }
  * }
  * ```
+ *
+ * @category Adapters
  */
 export function withSupabase(
   config?: Omit<WithSupabaseConfig, 'cors'>,

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -14,7 +14,7 @@ import { resolveEnv } from './resolve-env.js'
  * Uses a secret key for authentication, giving full access to all data.
  * Stateless — one client per request.
  *
- * @throws {@link EnvError} If `SUPABASE_URL` is missing or the specified secret key is not found.
+ * @throws {@link index.EnvError} If `SUPABASE_URL` is missing or the specified secret key is not found.
  *
  * @example
  * ```ts

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -21,6 +21,8 @@ import { resolveEnv } from './resolve-env.js'
  * const supabaseAdmin = createAdminClient()
  * const { data } = await supabaseAdmin.from('audit_log').insert({ action: 'user_login' })
  * ```
+ *
+ * @category Primitives
  */
 export function createAdminClient<Database = unknown>(
   options?: CreateAdminClientOptions,

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -24,6 +24,8 @@ import { resolveEnv } from './resolve-env.js'
  * })
  * const { data } = await supabase.rpc('get_my_items')
  * ```
+ *
+ * @category Primitives
  */
 export function createContextClient<Database = unknown>(
   options?: CreateContextClientOptions,

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -14,7 +14,7 @@ import { resolveEnv } from './resolve-env.js'
  * Configured with a publishable key and (optionally) the caller's JWT,
  * so Row-Level Security policies apply. Stateless — one client per request.
  *
- * @throws {@link EnvError} If `SUPABASE_URL` is missing or the specified publishable key is not found.
+ * @throws {@link index.EnvError} If `SUPABASE_URL` is missing or the specified publishable key is not found.
  *
  * @example
  * ```ts

--- a/src/core/extract-credentials.ts
+++ b/src/core/extract-credentials.ts
@@ -21,6 +21,8 @@ import type { Credentials } from '../types.js'
  * console.log(creds.token)  // "eyJhbGci..." or null
  * console.log(creds.apikey) // "sb-abc123-publishable-..." or null
  * ```
+ *
+ * @category Primitives
  */
 export function extractCredentials(request: Request): Credentials {
   const authHeader = request.headers.get('authorization')

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,12 +1,14 @@
 /**
- * Composable primitives for constructing a {@link SupabaseContext}.
+ * Composable primitives for constructing a {@link index.SupabaseContext}.
  * @packageDocumentation
  */
 
 export { resolveEnv } from './resolve-env.js'
 export { extractCredentials } from './extract-credentials.js'
 export { verifyCredentials } from './verify-credentials.js'
+export type { VerifyCredentialsOptions } from './verify-credentials.js'
 export { verifyAuth } from './verify-auth.js'
+export type { VerifyAuthOptions } from './verify-auth.js'
 export { createContextClient } from './create-context-client.js'
 export { createAdminClient } from './create-admin-client.js'
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 /**
  * Composable primitives for constructing a {@link index.SupabaseContext}.
+ * @module
  * @packageDocumentation
  */
 

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -157,6 +157,8 @@ function resolveJwks(): JSONWebKeySet | URL | null {
  * // Override for tests
  * const { data: env } = resolveEnv({ url: 'http://localhost:54321' })
  * ```
+ *
+ * @category Primitives
  */
 export function resolveEnv(
   overrides?: Partial<SupabaseEnv>,

--- a/src/core/verify-auth.ts
+++ b/src/core/verify-auth.ts
@@ -55,6 +55,8 @@ interface VerifyAuthOptions {
  *
  * console.log(auth.userClaims!.id) // "d0f1a2b3-..."
  * ```
+ *
+ * @category Primitives
  */
 export async function verifyAuth(
   request: Request,

--- a/src/core/verify-auth.ts
+++ b/src/core/verify-auth.ts
@@ -5,8 +5,9 @@ import { verifyCredentials } from './verify-credentials.js'
 
 /**
  * Options for {@link verifyAuth}.
+ * @category Primitives
  */
-interface VerifyAuthOptions {
+export interface VerifyAuthOptions {
   /**
    * Auth mode(s) to try. Modes are attempted in order — the first match wins.
    *

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -300,6 +300,8 @@ async function tryMode(
  *   return Response.json({ message: error.message }, { status: error.status })
  * }
  * ```
+ *
+ * @category Primitives
  */
 export async function verifyCredentials(
   credentials: Credentials,

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -95,6 +95,10 @@ function jwtClaimsToUserClaims(jwtClaims: JWTClaims): UserClaims {
 
 const INVALID = Symbol('invalid')
 
+/**
+ * A JWKS key resolver with an accessor for the cached key set.
+ * @category Primitives
+ */
 export type JwksResolver = JWTVerifyGetKey & {
   jwks: () => JSONWebKeySet | undefined
 }

--- a/src/core/verify-credentials.ts
+++ b/src/core/verify-credentials.ts
@@ -25,8 +25,9 @@ import { resolveEnv } from './resolve-env.js'
 
 /**
  * Options for {@link verifyCredentials}.
+ * @category Primitives
  */
-interface VerifyCredentialsOptions {
+export interface VerifyCredentialsOptions {
   /**
    * Auth mode(s) to try. Modes are attempted in order — the first match wins.
    *

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -20,6 +20,8 @@ import { verifyAuth } from './core/verify-auth.js'
  * @param options - Auth modes, environment overrides. The `cors` option is ignored here.
  * @returns `{ data: SupabaseContext, error: null }` on success, `{ data: null, error: AuthError }` on failure.
  *
+ * @category Middleware
+ *
  * @example
  * ```ts
  * const { data: ctx, error } = await createSupabaseContext(request, { auth: 'user' })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,6 +16,8 @@
  *   }
  * }
  * ```
+ *
+ * @category Errors
  */
 export class EnvError extends Error {
   /** Always `500` — environment errors are server-side issues. */
@@ -37,23 +39,41 @@ export class EnvError extends Error {
   }
 }
 
-/** Generic environment error code. */
+/**
+ * Generic environment error code.
+ * @category Errors
+ */
 export const EnvGenericError = 'ENV_ERROR'
 
-/** `SUPABASE_URL` is not set. */
+/**
+ * `SUPABASE_URL` is not set.
+ * @category Errors
+ */
 export const MissingSupabaseURLError = 'MISSING_SUPABASE_URL'
 
-/** Named publishable key not found in `SUPABASE_PUBLISHABLE_KEYS`. */
+/**
+ * Named publishable key not found in `SUPABASE_PUBLISHABLE_KEYS`.
+ * @category Errors
+ */
 export const MissingPublishableKeyError = 'MISSING_PUBLISHABLE_KEY'
 
-/** No default publishable key found. */
+/**
+ * No default publishable key found.
+ * @category Errors
+ */
 export const MissingDefaultPublishableKeyError =
   'MISSING_DEFAULT_PUBLISHABLE_KEY'
 
-/** Named secret key not found in `SUPABASE_SECRET_KEYS`. */
+/**
+ * Named secret key not found in `SUPABASE_SECRET_KEYS`.
+ * @category Errors
+ */
 export const MissingSecretKeyError = 'MISSING_SECRET_KEY'
 
-/** No default secret key found. */
+/**
+ * No default secret key found.
+ * @category Errors
+ */
 export const MissingDefaultSecretKeyError = 'MISSING_DEFAULT_SECRET_KEY'
 
 const EnvErrorMap = {
@@ -104,6 +124,8 @@ const EnvErrorMap = {
  *   )
  * }
  * ```
+ *
+ * @category Errors
  */
 export class AuthError extends Error {
   /**
@@ -130,13 +152,22 @@ export class AuthError extends Error {
   }
 }
 
-/** Generic authentication error code. */
+/**
+ * Generic authentication error code.
+ * @category Errors
+ */
 export const AuthGenericError = 'AUTH_ERROR'
 
-/** No credential matched any allowed auth mode. */
+/**
+ * No credential matched any allowed auth mode.
+ * @category Errors
+ */
 export const InvalidCredentialsError = 'INVALID_CREDENTIALS'
 
-/** Failed to create a Supabase client after auth succeeded. */
+/**
+ * Failed to create a Supabase client after auth succeeded.
+ * @category Errors
+ */
 export const CreateSupabaseClientError = 'CREATE_SUPABASE_CLIENT_ERROR'
 
 const AuthErrorMap = {
@@ -159,6 +190,8 @@ const AuthErrorMap = {
  * throw Errors[MissingSupabaseURLError]()
  * throw Errors[MissingPublishableKeyError]('mobile')
  * ```
+ *
+ * @category Errors
  */
 export const Errors = {
   ...EnvErrorMap,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 /**
  * Server-side Supabase utilities for modern runtimes.
+ * @module
  * @packageDocumentation
  */
 

--- a/src/peer/supabase-js/index.ts
+++ b/src/peer/supabase-js/index.ts
@@ -9,6 +9,7 @@
  * second package — `@supabase/server` becomes a single import surface.
  *
  *
+ * @module
  * @packageDocumentation
  */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,11 +26,14 @@ export type { JSONWebKeySet }
  * // through to the next mode.
  * withSupabase({ auth: ['user', 'publishable'] }, handler)
  * ```
+ *
+ * @category Types
  */
 export type AuthMode = 'none' | 'publishable' | 'secret' | 'user'
 
 /**
  * @deprecated Use {@link AuthMode} instead. Will be removed in a future major release.
+ * @category Types
  */
 export type Allow = AuthMode
 
@@ -52,6 +55,8 @@ export type Allow = AuthMode
  * // Mix named keys with other modes
  * withSupabase({ auth: ['user', 'publishable:web_app'] }, handler)
  * ```
+ *
+ * @category Types
  */
 export type AuthModeWithKey =
   | AuthMode
@@ -60,6 +65,7 @@ export type AuthModeWithKey =
 
 /**
  * @deprecated Use {@link AuthModeWithKey} instead. Will be removed in a future major release.
+ * @category Types
  */
 export type AllowWithKey = AuthModeWithKey
 
@@ -71,6 +77,7 @@ export type AllowWithKey = AuthModeWithKey
  * but can be passed explicitly via the `env` option.
  *
  * @see {@link resolveEnv} for how each field maps to environment variables.
+ * @category Types
  */
 export interface SupabaseEnv {
   /** Supabase project URL (e.g. `"https://<ref>.supabase.co"`). Sourced from `SUPABASE_URL`. */
@@ -113,6 +120,7 @@ export interface SupabaseEnv {
  * Produced by {@link extractCredentials} from the `Authorization` and `apikey` headers.
  *
  * @see {@link extractCredentials}
+ * @category Types
  */
 export interface Credentials {
   /** Bearer token from the `Authorization: Bearer <token>` header, or `null` if absent. */
@@ -130,6 +138,7 @@ export interface Credentials {
  *
  * @see {@link verifyCredentials}
  * @see {@link verifyAuth}
+ * @category Types
  */
 export interface AuthResult {
   /** The auth mode that was successfully matched. */
@@ -154,6 +163,7 @@ export interface AuthResult {
  * This is the raw JWT payload — use {@link UserClaims} for a normalized, camelCase view.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+ * @category Types
  */
 export interface JWTClaims {
   /** Subject — the user's unique ID. */
@@ -193,6 +203,7 @@ export interface JWTClaims {
  * Derived from {@link JWTClaims}. For the full Supabase `User` object
  * (including email confirmation status, providers, etc.), call
  * `supabase.auth.getUser()` using the context client.
+ * @category Types
  */
 export interface UserClaims {
   /** User's unique ID (same as `JWTClaims.sub`). */
@@ -230,6 +241,8 @@ export interface UserClaims {
  * // No auth required, CORS disabled
  * const config: WithSupabaseConfig = { auth: 'none', cors: false }
  * ```
+ *
+ * @category Types
  */
 export interface WithSupabaseConfig {
   /**
@@ -289,6 +302,7 @@ export interface WithSupabaseConfig {
  * Auth identity for client creation functions.
  *
  * @see {@link verifyAuth}, {@link verifyCredentials}
+ * @category Types
  */
 export interface ClientAuth {
   /** The caller's JWT, or `null` for anonymous access. */
@@ -298,7 +312,10 @@ export interface ClientAuth {
   keyName?: string | null
 }
 
-/** Options for {@link createContextClient}. */
+/**
+ * Options for {@link createContextClient}.
+ * @category Types
+ */
 export interface CreateContextClientOptions {
   /** Auth identity — token and key name from the verified request. */
   auth?: ClientAuth
@@ -310,7 +327,10 @@ export interface CreateContextClientOptions {
   supabaseOptions?: SupabaseClientOptions<string>
 }
 
-/** Options for {@link createAdminClient}. */
+/**
+ * Options for {@link createAdminClient}.
+ * @category Types
+ */
 export interface CreateAdminClientOptions {
   /** Auth identity — key name from the verified request. */
   auth?: Pick<ClientAuth, 'keyName'>
@@ -327,6 +347,7 @@ export interface CreateAdminClientOptions {
  *
  * Contains pre-configured Supabase clients and the caller's identity.
  * Identical regardless of which layer or adapter produced it.
+ * @category Types
  */
 export interface SupabaseContext<Database = unknown> {
   /** Supabase client scoped to the caller's identity. RLS policies apply. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,10 +73,10 @@ export type AllowWithKey = AuthModeWithKey
  * Resolved Supabase environment configuration.
  *
  * Holds the project URL, API keys, and JWKS needed by every other primitive.
- * Typically resolved automatically from environment variables by {@link resolveEnv},
+ * Typically resolved automatically from environment variables by {@link core.resolveEnv},
  * but can be passed explicitly via the `env` option.
  *
- * @see {@link resolveEnv} for how each field maps to environment variables.
+ * @see {@link core.resolveEnv} for how each field maps to environment variables.
  * @category Types
  */
 export interface SupabaseEnv {
@@ -99,8 +99,8 @@ export interface SupabaseEnv {
    * JWKS source used for JWT verification.
    *
    * Sourced from one of (in priority order):
-   * - `SUPABASE_JWKS` — inline JSON. Resolves to a {@link JsonWebKeySet}.
-   * - `SUPABASE_JWKS_URL` — remote endpoint. Resolves to a {@link URL}; keys
+   * - `SUPABASE_JWKS` — inline JSON. Resolves to a `JSONWebKeySet`.
+   * - `SUPABASE_JWKS_URL` — remote endpoint. Resolves to a `URL`; keys
    *   are fetched lazily and cached in memory (cooldown / max-age handled by
    *   `jose`). `https://` is always accepted; plain `http://` is accepted
    *   only for loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) to support
@@ -117,9 +117,9 @@ export interface SupabaseEnv {
 /**
  * Raw credentials extracted from an incoming HTTP request.
  *
- * Produced by {@link extractCredentials} from the `Authorization` and `apikey` headers.
+ * Produced by {@link core.extractCredentials} from the `Authorization` and `apikey` headers.
  *
- * @see {@link extractCredentials}
+ * @see {@link core.extractCredentials}
  * @category Types
  */
 export interface Credentials {
@@ -136,8 +136,8 @@ export interface Credentials {
  * Contains the resolved auth mode, the verified token (for `"user"` mode),
  * decoded JWT claims, and the matched key name (for `"publishable"` / `"secret"` modes).
  *
- * @see {@link verifyCredentials}
- * @see {@link verifyAuth}
+ * @see {@link core.verifyCredentials}
+ * @see {@link core.verifyAuth}
  * @category Types
  */
 export interface AuthResult {
@@ -301,7 +301,7 @@ export interface WithSupabaseConfig {
 /**
  * Auth identity for client creation functions.
  *
- * @see {@link verifyAuth}, {@link verifyCredentials}
+ * @see {@link core.verifyAuth}, {@link core.verifyCredentials}
  * @category Types
  */
 export interface ClientAuth {
@@ -313,7 +313,7 @@ export interface ClientAuth {
 }
 
 /**
- * Options for {@link createContextClient}.
+ * Options for {@link core.createContextClient}.
  * @category Types
  */
 export interface CreateContextClientOptions {
@@ -328,7 +328,7 @@ export interface CreateContextClientOptions {
 }
 
 /**
- * Options for {@link createAdminClient}.
+ * Options for {@link core.createAdminClient}.
  * @category Types
  */
 export interface CreateAdminClientOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type {
   SupabaseClientOptions,
 } from '@supabase/supabase-js'
 
+/** @category Types */
 export type { JSONWebKeySet }
 
 /**

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -13,6 +13,8 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
  * @param handler - Receives the `Request` and a fully-initialized {@link SupabaseContext}.
  * @returns A `(req: Request) => Promise<Response>` fetch handler.
  *
+ * @category Middleware
+ *
  * @example
  * ```ts
  * import { withSupabase } from '@supabase/server'

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,8 +5,7 @@
     "src/core/index.ts",
     "src/adapters/hono/index.ts",
     "src/adapters/h3/index.ts",
-    "src/adapters/elysia/index.ts",
-    "src/adapters/nestjs/index.ts"
+    "src/adapters/elysia/index.ts"
   ],
   "out": "api-docs",
   "json": "api-docs/spec.json",
@@ -26,10 +25,18 @@
     "docs/auth-modes.md",
     "docs/environment-variables.md",
     "docs/error-handling.md",
-    "docs/hono-adapter.md",
     "docs/security.md",
     "docs/ssr-frameworks.md",
     "docs/typescript-generics.md"
+  ],
+  "highlightLanguages": [
+    "typescript",
+    "javascript",
+    "tsx",
+    "bash",
+    "sh",
+    "toml",
+    "json"
   ],
   "sort": ["source-order"],
   "kindSortOrder": ["Function", "Class", "Interface", "TypeAlias", "Enum"],

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,8 @@
     "src/core/index.ts",
     "src/adapters/hono/index.ts",
     "src/adapters/h3/index.ts",
-    "src/adapters/elysia/index.ts"
+    "src/adapters/elysia/index.ts",
+    "src/adapters/nestjs/index.ts"
   ],
   "out": "api-docs",
   "json": "api-docs/spec.json",


### PR DESCRIPTION
Prepares the public API for TypeDoc-based reference documentation in the supabase/supabase docs repo, and fixes two failing JSR score criteria.

## What changed

**TypeDoc: `@category` tags**
- Added `@category` tags (Primitives, Types, Errors, Adapters, Middleware) to all publicly exported functions, types, classes, and error constants so TypeDoc can group them for reference navigation.

**TypeDoc: cross-module `{@link}` references**
- Updated `{@link}` references throughout `src/types.ts` and adapter files to use module-qualified names (e.g. `{@link core.resolveEnv}`, `{@link index.EnvError}`) so TypeDoc resolves cross-entrypoint links correctly instead of producing broken anchors.

**TypeDoc: new exports**
- `VerifyAuthOptions` and `VerifyCredentialsOptions` are now exported from `@supabase/server/core`. Both were previously internal interfaces but are part of the public API surface.

**TypeDoc: `typedoc.json` updates**
- Added explicit `highlightLanguages` list (`typescript`, `javascript`, `tsx`, `bash`, `sh`, `toml`, `json`) so code blocks in docs render with correct syntax highlighting.
- Removed `docs/hono-adapter.md` from the extras list (no longer needed).

**JSR score: module docs**
- Added `@module` tag to the JSDoc comment in all 7 entrypoint files (`src/index.ts`, `src/core/index.ts`, `src/peer/supabase-js/index.ts`, and the four adapter entrypoints). JSR's scoring requires `@module` to identify a comment as a module-level doc; `@packageDocumentation` alone (TypeDoc's convention) is not recognized by JSR. Both tags now coexist.