### PR TITLE
fix: expand @module comment to restore rich JSR overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,14 @@
 
 ## [1.3.0](https://github.com/supabase/server/compare/server-v1.2.0...server-v1.3.0) (2026-07-03)
 
-
 ### Features
 
-* add attw type export checking to CI ([#93](https://github.com/supabase/server/issues/93)) ([e1e2b72](https://github.com/supabase/server/commit/e1e2b72e81660c787b0445dbdf69946b95324abd))
-
+- add attw type export checking to CI ([#93](https://github.com/supabase/server/issues/93)) ([e1e2b72](https://github.com/supabase/server/commit/e1e2b72e81660c787b0445dbdf69946b95324abd))
 
 ### Bug Fixes
 
-* add ./peer/supabase-js to jsr.json exports ([#94](https://github.com/supabase/server/issues/94)) ([04276d0](https://github.com/supabase/server/commit/04276d015c8b65f50c1944a9e8407fe01f444703))
-* **test:** correct sub claim in remote JWKS token fixture and wire tests into CI ([#89](https://github.com/supabase/server/issues/89)) ([744105b](https://github.com/supabase/server/commit/744105b458e637b5211021d3e6b9de2d91da6b72))
+- add ./peer/supabase-js to jsr.json exports ([#94](https://github.com/supabase/server/issues/94)) ([04276d0](https://github.com/supabase/server/commit/04276d015c8b65f50c1944a9e8407fe01f444703))
+- **test:** correct sub claim in remote JWKS token fixture and wire tests into CI ([#89](https://github.com/supabase/server/issues/89)) ([744105b](https://github.com/supabase/server/commit/744105b458e637b5211021d3e6b9de2d91da6b72))
 
 ## [1.2.0](https://github.com/supabase/server/compare/server-v1.1.0...server-v1.2.0) (2026-06-17)
 

--- a/jsr.json
+++ b/jsr.json
@@ -11,14 +11,7 @@
     "./adapters/nestjs": "./src/adapters/nestjs/index.ts"
   },
   "publish": {
-    "include": [
-      "src/**/*.ts",
-      "README.md",
-      "LICENSE"
-    ],
-    "exclude": [
-      "src/**/*.test.ts",
-      "src/**/*.spec.ts"
-    ]
+    "include": ["src/**/*.ts", "README.md", "LICENSE"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,63 @@
 /**
  * Server-side Supabase utilities for modern runtimes.
+ *
+ * `@supabase/server` gives you batteries-included auth and client creation for
+ * Edge Functions, Workers, and any server runtime that speaks standard `fetch`.
+ * One import, one line of config — auth is verified, Supabase clients are ready,
+ * CORS is handled. Your handler only runs on successful auth.
+ *
+ * ```ts
+ * import { withSupabase } from '@supabase/server'
+ *
+ * export default {
+ *   fetch: withSupabase({ auth: 'user' }, async (_req, ctx) => {
+ *     const { data: myGames } = await ctx.supabase.from('favorite_games').select()
+ *     return Response.json(myGames)
+ *   }),
+ * }
+ * ```
+ *
+ * ## Auth modes
+ *
+ * | Mode | Credential | Use case |
+ * |------|-----------|----------|
+ * | `"user"` | Valid JWT | Authenticated user endpoints |
+ * | `"publishable"` | Publishable key | Client-facing, key-validated endpoints |
+ * | `"secret"` | Secret key | Server-to-server, internal calls |
+ * | `"none"` | None | Open endpoints |
+ *
+ * Array syntax tries modes in order — first match wins:
+ * ```ts
+ * withSupabase({ auth: ['user', 'secret'] }, handler)
+ * ```
+ *
+ * ## Framework adapters
+ *
+ * Adapters for Hono, H3 / Nuxt, Elysia, and NestJS ship inside this package:
+ *
+ * ```ts
+ * import { withSupabase } from '@supabase/server/adapters/hono'
+ * import { withSupabase } from '@supabase/server/adapters/h3'
+ * import { withSupabase } from '@supabase/server/adapters/elysia'
+ * import { withSupabase, SupabaseCtx } from '@supabase/server/adapters/nestjs'
+ * ```
+ *
+ * ## Composable primitives
+ *
+ * For custom flows, all lower-level functions are available from `@supabase/server/core`:
+ *
+ * ```ts
+ * import { verifyAuth, createContextClient, createAdminClient } from '@supabase/server/core'
+ * ```
+ *
+ * ## Installation
+ *
+ * ```sh
+ * npm install @supabase/server
+ * # or
+ * deno add jsr:@supabase/server
+ * ```
+ *
  * @module
  * @packageDocumentation
  */


### PR DESCRIPTION
Adding `@module` to the entry point (for JSR docs score) caused JSR to display only the one-line JSDoc summary on the package overview page instead of the README. This PR expands the `@module` comment in `src/index.ts` with a full markdown overview — description, quick example, auth modes table, adapter imports, primitives, and install instructions — so the JSR overview is rich again without sacrificing the 100% docs score.