### PR TITLE
fix: add hono adapter Database type override

### DIFF
--- a/docs/typescript-generics.md
+++ b/docs/typescript-generics.md
@@ -101,6 +101,26 @@ app.get('/todos', async (c) => {
 })
 ```
 
+Alternatively, skip the `Env` type and thread `Database` through the `withSupabase<Database>()` generic when using chained declarations. Hono infers the `supabaseContext` variable type from the middleware, so `c.var.supabaseContext.supabase` is still a fully typed `SupabaseClient<Database>`. This plays a little nicer with hono [sub-application routes](https://hono.dev/docs/helpers/route#working-with-sub-applications).
+
+```ts
+import { Hono } from 'hono'
+import { withSupabase } from '@supabase/server/adapters/hono'
+import type { Database } from './database.types.ts'
+
+const app = new Hono()
+
+const todosApp = new Hono()
+  .use(withSupabase<Database>({ auth: 'user' }))
+  .get('/', async (c) => {
+    const { supabase } = c.var.supabaseContext
+    const { data } = await supabase.from('todos').select('id, title')
+    return c.json(data)
+  })
+
+app.route('/todos', todosApp)
+```
+
 ## Custom schema
 
 If your tables are in a schema other than `public`, pass it via `supabaseOptions`:

--- a/src/adapters/hono/middleware.test.ts
+++ b/src/adapters/hono/middleware.test.ts
@@ -69,6 +69,22 @@ describe('hono supabase middleware', () => {
     expect(res.status).toBe(200)
   })
 
+  it('uses the Hono adapter to type the Supabase context', async () => {
+    // match docs example in typescript-generics.md
+    const app = new Hono()
+    const rootApp = new Hono()
+      .use(withSupabase<Database>({ auth: 'none', env }))
+      .get('/', (c) => {
+        const ctx = c.var.supabaseContext
+        expectTypeOf(ctx).toEqualTypeOf<SupabaseContext<Database>>()
+        return c.json({ authMode: ctx.authMode })
+      })
+    app.route('/', rootApp)
+
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+  })
+
   it('throws HTTPException on auth failure', async () => {
     const app = new Hono()
     app.use('*', withSupabase({ auth: 'user', env }))

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -40,11 +40,13 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  *
  * @category Adapters
  */
-export function withSupabase(
+export function withSupabase<Database = unknown>(
   config?: Omit<WithSupabaseConfig, 'cors'>,
-): MiddlewareHandler<{ Variables: { supabaseContext: SupabaseContext } }> {
+): MiddlewareHandler<{
+  Variables: { supabaseContext: SupabaseContext<Database> }
+}> {
   return createMiddleware<{
-    Variables: { supabaseContext: SupabaseContext }
+    Variables: { supabaseContext: SupabaseContext<Database> }
   }>(async (c, next) => {
     // Skip if a previous middleware already set the context.
     // This enables route-level overrides: a route can use withSupabase({ auth: 'secret' })
@@ -55,7 +57,10 @@ export function withSupabase(
       return
     }
 
-    const { data: ctx, error } = await createSupabaseContext(c.req.raw, config)
+    const { data: ctx, error } = await createSupabaseContext<Database>(
+      c.req.raw,
+      config,
+    )
     if (error) {
       throw new HTTPException(error.status as 401 | 500, {
         message: error.message,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix hono adapter type definitions.

## What is the current behavior?

There is no way to override the DB context returned by the `withSupabase` middleware without doing so in the Hono app itself.

## What is the new behavior?

Make the hono `withSupabase` adapter more type-aware. Allow Database type overrides in the hono middleware.

## Additional context

For growing projects, managing routes with hono's [route helpers](https://hono.dev/docs/helpers/route#working-with-sub-applications) via sub-applications generally becomes best practice when scalaing a hono api. In those scenarios, it's common to see many hono "apps" or routes defined across a stack. This change allows users to just use the hono middleware without needing to pre-declare any context types.
