### PR TITLE
feat: explicit cors config shape ('default' | 'disabled' | { headers })

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ interface SupabaseContext {
 withSupabase(
   {
     auth: 'user', // who can call this function
-    cors: 'none', // disable CORS (default: supabase-js CORS headers)
+    cors: 'disabled', // disable CORS (default: supabase-js CORS headers)
     env: { url: '...' }, // env overrides (optional)
   },
   handler,
 )
 ```
 
-`cors` accepts `'default'` (the standard [supabase-js CORS headers](https://supabase.com/docs/guides/functions/cors), also the default), `'none'` to disable CORS handling (e.g. when using a framework that handles CORS separately), or `{ headers }` to set custom headers. The boolean (`true`/`false`) and bare `Record<string, string>` forms are deprecated but still accepted.
+`cors` accepts `'default'` (the standard [supabase-js CORS headers](https://supabase.com/docs/guides/functions/cors), also the default), `'disabled'` to disable CORS handling (e.g. when using a framework that handles CORS separately), or `{ headers }` to set custom headers. The boolean (`true`/`false`) and bare `Record<string, string>` forms are deprecated but still accepted.
 
 ```ts
 withSupabase(

--- a/README.md
+++ b/README.md
@@ -236,22 +236,24 @@ interface SupabaseContext {
 withSupabase(
   {
     auth: 'user', // who can call this function
-    cors: false, // disable CORS (default: supabase-js CORS headers)
+    cors: 'none', // disable CORS (default: supabase-js CORS headers)
     env: { url: '...' }, // env overrides (optional)
   },
   handler,
 )
 ```
 
-`cors` defaults to the standard [supabase-js CORS headers](https://supabase.com/docs/guides/functions/cors). Pass a `Record<string, string>` to set custom headers, or `false` to disable CORS handling (e.g. when using a framework that handles CORS separately).
+`cors` accepts `'default'` (the standard [supabase-js CORS headers](https://supabase.com/docs/guides/functions/cors), also the default), `'none'` to disable CORS handling (e.g. when using a framework that handles CORS separately), or `{ headers }` to set custom headers. The boolean (`true`/`false`) and bare `Record<string, string>` forms are deprecated but still accepted.
 
 ```ts
 withSupabase(
   {
     auth: 'user',
     cors: {
-      'Access-Control-Allow-Origin': 'https://myapp.com',
-      'Access-Control-Allow-Headers': 'authorization, content-type',
+      headers: {
+        'Access-Control-Allow-Origin': 'https://myapp.com',
+        'Access-Control-Allow-Headers': 'authorization, content-type',
+      },
     },
   },
   handler,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,10 +136,10 @@ withSupabase(
 )
 
 // Disable CORS (e.g., when a framework handles it)
-withSupabase({ auth: 'user', cors: 'none' }, handler)
+withSupabase({ auth: 'user', cors: 'disabled' }, handler)
 ```
 
-`cors` accepts `'default'` (standard supabase-js headers), `'none'` (disabled), or
+`cors` accepts `'default'` (standard supabase-js headers), `'disabled'`, or
 `{ headers }` for custom headers. The boolean (`true`/`false`) and bare
 `Record<string, string>` forms are deprecated but still accepted.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,16 +126,22 @@ withSupabase(
   {
     auth: 'user',
     cors: {
-      'Access-Control-Allow-Origin': 'https://myapp.com',
-      'Access-Control-Allow-Headers': 'authorization, content-type',
+      headers: {
+        'Access-Control-Allow-Origin': 'https://myapp.com',
+        'Access-Control-Allow-Headers': 'authorization, content-type',
+      },
     },
   },
   handler,
 )
 
 // Disable CORS (e.g., when a framework handles it)
-withSupabase({ auth: 'user', cors: false }, handler)
+withSupabase({ auth: 'user', cors: 'none' }, handler)
 ```
+
+`cors` accepts `'default'` (standard supabase-js headers), `'none'` (disabled), or
+`{ headers }` for custom headers. The boolean (`true`/`false`) and bare
+`Record<string, string>` forms are deprecated but still accepted.
 
 ## Runtimes
 

--- a/src/cors.test.ts
+++ b/src/cors.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { addCorsHeaders, buildCorsHeaders } from './cors.js'
+import { addCorsHeaders, buildCorsHeaders, isCorsDisabled } from './cors.js'
 
 describe('buildCorsHeaders', () => {
-  it('returns supabase-js defaults when config is true', () => {
-    const headers = buildCorsHeaders(true)
+  it("returns supabase-js defaults when config is 'default'", () => {
+    const headers = buildCorsHeaders('default')
     expect(headers['Access-Control-Allow-Origin']).toBe('*')
     expect(headers['Access-Control-Allow-Methods']).toContain('GET')
     expect(headers['Access-Control-Allow-Headers']).toContain('authorization')
@@ -15,16 +15,51 @@ describe('buildCorsHeaders', () => {
     expect(headers['Access-Control-Allow-Origin']).toBe('*')
   })
 
-  it('returns empty object when config is false', () => {
+  it("returns empty object when config is 'none'", () => {
+    expect(buildCorsHeaders('none')).toEqual({})
+  })
+
+  it('returns the inner headers from the { headers } shape', () => {
+    const headers = {
+      'Access-Control-Allow-Origin': 'https://example.com',
+      'Access-Control-Allow-Headers': 'X-Custom',
+    }
+    expect(buildCorsHeaders({ headers })).toBe(headers)
+  })
+
+  // Deprecated forms — still supported for backward compatibility.
+  it('returns supabase-js defaults when config is true (deprecated)', () => {
+    const headers = buildCorsHeaders(true)
+    expect(headers['Access-Control-Allow-Origin']).toBe('*')
+    expect(headers['Access-Control-Allow-Methods']).toContain('GET')
+    expect(headers['Access-Control-Allow-Headers']).toContain('authorization')
+  })
+
+  it('returns empty object when config is false (deprecated)', () => {
     expect(buildCorsHeaders(false)).toEqual({})
   })
 
-  it('returns custom headers as-is', () => {
+  it('returns a bare custom headers record as-is (deprecated)', () => {
     const custom = {
       'Access-Control-Allow-Origin': 'https://example.com',
       'Access-Control-Allow-Headers': 'X-Custom',
     }
     expect(buildCorsHeaders(custom)).toBe(custom)
+  })
+})
+
+describe('isCorsDisabled', () => {
+  it("is true for 'none' and the deprecated false", () => {
+    expect(isCorsDisabled('none')).toBe(true)
+    expect(isCorsDisabled(false)).toBe(true)
+  })
+
+  it('is false for enabled configurations', () => {
+    expect(isCorsDisabled('default')).toBe(false)
+    expect(isCorsDisabled(true)).toBe(false)
+    expect(isCorsDisabled()).toBe(false)
+    expect(isCorsDisabled({ headers: { 'X-Custom': '1' } })).toBe(false)
+    expect(isCorsDisabled({ 'Access-Control-Allow-Origin': '*' })).toBe(false)
   })
 })
 
@@ -35,13 +70,29 @@ describe('addCorsHeaders', () => {
     expect(result.headers.get('Access-Control-Allow-Origin')).toBe('*')
   })
 
-  it('returns response unchanged when config is false', () => {
+  it("returns response unchanged when config is 'none'", () => {
+    const response = new Response('ok')
+    const result = addCorsHeaders(response, 'none')
+    expect(result.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('returns response unchanged when config is false (deprecated)', () => {
     const response = new Response('ok')
     const result = addCorsHeaders(response, false)
     expect(result.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 
-  it('adds custom headers to response', () => {
+  it('adds custom headers from the { headers } shape to response', () => {
+    const response = new Response('ok')
+    const result = addCorsHeaders(response, {
+      headers: { 'Access-Control-Allow-Origin': 'https://example.com' },
+    })
+    expect(result.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://example.com',
+    )
+  })
+
+  it('adds a bare custom headers record to response (deprecated)', () => {
     const response = new Response('ok')
     const result = addCorsHeaders(response, {
       'Access-Control-Allow-Origin': 'https://example.com',

--- a/src/cors.test.ts
+++ b/src/cors.test.ts
@@ -15,8 +15,8 @@ describe('buildCorsHeaders', () => {
     expect(headers['Access-Control-Allow-Origin']).toBe('*')
   })
 
-  it("returns empty object when config is 'none'", () => {
-    expect(buildCorsHeaders('none')).toEqual({})
+  it("returns empty object when config is 'disabled'", () => {
+    expect(buildCorsHeaders('disabled')).toEqual({})
   })
 
   it('returns the inner headers from the { headers } shape', () => {
@@ -49,8 +49,8 @@ describe('buildCorsHeaders', () => {
 })
 
 describe('isCorsDisabled', () => {
-  it("is true for 'none' and the deprecated false", () => {
-    expect(isCorsDisabled('none')).toBe(true)
+  it("is true for 'disabled' and the deprecated false", () => {
+    expect(isCorsDisabled('disabled')).toBe(true)
     expect(isCorsDisabled(false)).toBe(true)
   })
 
@@ -70,9 +70,9 @@ describe('addCorsHeaders', () => {
     expect(result.headers.get('Access-Control-Allow-Origin')).toBe('*')
   })
 
-  it("returns response unchanged when config is 'none'", () => {
+  it("returns response unchanged when config is 'disabled'", () => {
     const response = new Response('ok')
-    const result = addCorsHeaders(response, 'none')
+    const result = addCorsHeaders(response, 'disabled')
     expect(result.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -3,13 +3,35 @@ import { corsHeaders as defaultCorsHeaders } from '@supabase/supabase-js/cors'
 /**
  * CORS configuration for {@link withSupabase}.
  *
- * - `true` — uses `@supabase/supabase-js` default CORS headers.
- * - `false` — disables CORS handling entirely.
- * - `Record<string, string>` — custom CORS headers to use.
+ * - `'default'` — uses `@supabase/supabase-js` default CORS headers.
+ * - `'none'` — disables CORS handling entirely.
+ * - `{ headers }` — custom CORS headers to use.
+ *
+ * The boolean (`true`/`false`) and bare `Record<string, string>` forms are
+ * deprecated but still accepted for backward compatibility.
  *
  * @internal
  */
-type CorsConfig = boolean | Record<string, string>
+type CorsConfig =
+  | 'default'
+  | 'none'
+  | { headers: Record<string, string> }
+  /** @deprecated Use `'default'` | `'none'` | `{ headers }` instead. */
+  | boolean
+  /** @deprecated Use `{ headers }` instead. */
+  | Record<string, string>
+
+/**
+ * Whether the given CORS configuration disables CORS handling.
+ *
+ * @param config - The CORS configuration.
+ * @returns `true` for `'none'` or the deprecated `false`, otherwise `false`.
+ *
+ * @internal
+ */
+export function isCorsDisabled(config?: CorsConfig): boolean {
+  return config === false || config === 'none'
+}
 
 /**
  * Builds the CORS headers object based on the given configuration.
@@ -20,8 +42,14 @@ type CorsConfig = boolean | Record<string, string>
  * @internal
  */
 export function buildCorsHeaders(config?: CorsConfig): Record<string, string> {
-  if (config === false) return {}
-  if (typeof config === 'object') return config
+  if (isCorsDisabled(config)) return {}
+  if (typeof config === 'object') {
+    // New `{ headers }` shape vs the deprecated bare `Record<string, string>`.
+    if ('headers' in config && typeof config.headers === 'object') {
+      return config.headers
+    }
+    return config as Record<string, string>
+  }
   return defaultCorsHeaders
 }
 
@@ -29,7 +57,7 @@ export function buildCorsHeaders(config?: CorsConfig): Record<string, string> {
  * Returns a new `Response` with CORS headers appended.
  *
  * Creates a clone of the original response and sets each CORS header on it.
- * If CORS is disabled (`config === false`), returns the original response unchanged.
+ * If CORS is disabled (`'none'` or the deprecated `false`), returns the original response unchanged.
  *
  * @param response - The original response to augment.
  * @param config - The CORS configuration.
@@ -41,7 +69,7 @@ export function addCorsHeaders(
   response: Response,
   config?: CorsConfig,
 ): Response {
-  if (config === false) return response
+  if (isCorsDisabled(config)) return response
 
   const corsHeaders = buildCorsHeaders(config)
   const newResponse = new Response(response.body, response)

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -4,7 +4,7 @@ import { corsHeaders as defaultCorsHeaders } from '@supabase/supabase-js/cors'
  * CORS configuration for {@link withSupabase}.
  *
  * - `'default'` — uses `@supabase/supabase-js` default CORS headers.
- * - `'none'` — disables CORS handling entirely.
+ * - `'disabled'` — disables CORS handling entirely.
  * - `{ headers }` — custom CORS headers to use.
  *
  * The boolean (`true`/`false`) and bare `Record<string, string>` forms are
@@ -14,9 +14,9 @@ import { corsHeaders as defaultCorsHeaders } from '@supabase/supabase-js/cors'
  */
 type CorsConfig =
   | 'default'
-  | 'none'
+  | 'disabled'
   | { headers: Record<string, string> }
-  /** @deprecated Use `'default'` | `'none'` | `{ headers }` instead. */
+  /** @deprecated Use `'default'` | `'disabled'` | `{ headers }` instead. */
   | boolean
   /** @deprecated Use `{ headers }` instead. */
   | Record<string, string>
@@ -25,12 +25,12 @@ type CorsConfig =
  * Whether the given CORS configuration disables CORS handling.
  *
  * @param config - The CORS configuration.
- * @returns `true` for `'none'` or the deprecated `false`, otherwise `false`.
+ * @returns `true` for `'disabled'` or the deprecated `false`, otherwise `false`.
  *
  * @internal
  */
 export function isCorsDisabled(config?: CorsConfig): boolean {
-  return config === false || config === 'none'
+  return config === false || config === 'disabled'
 }
 
 /**
@@ -57,7 +57,7 @@ export function buildCorsHeaders(config?: CorsConfig): Record<string, string> {
  * Returns a new `Response` with CORS headers appended.
  *
  * Creates a clone of the original response and sets each CORS header on it.
- * If CORS is disabled (`'none'` or the deprecated `false`), returns the original response unchanged.
+ * If CORS is disabled (`'disabled'` or the deprecated `false`), returns the original response unchanged.
  *
  * @param response - The original response to augment.
  * @param config - The CORS configuration.

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,7 +239,7 @@ export interface UserClaims {
  * }
  *
  * // No auth required, CORS disabled
- * const config: WithSupabaseConfig = { auth: 'none', cors: 'none' }
+ * const config: WithSupabaseConfig = { auth: 'none', cors: 'disabled' }
  * ```
  *
  * @category Types
@@ -271,7 +271,7 @@ export interface WithSupabaseConfig {
    * CORS configuration for the `withSupabase` wrapper.
    *
    * - `'default'` — uses `@supabase/supabase-js` default CORS headers.
-   * - `'none'` — disables CORS handling entirely.
+   * - `'disabled'` — disables CORS handling entirely.
    * - `{ headers }` — custom CORS headers.
    *
    * The boolean (`true`/`false`) and bare `Record<string, string>` forms are
@@ -285,9 +285,9 @@ export interface WithSupabaseConfig {
    */
   cors?:
     | 'default'
-    | 'none'
+    | 'disabled'
     | { headers: Record<string, string> }
-    /** @deprecated Use `'default'` | `'none'` | `{ headers }` instead. */
+    /** @deprecated Use `'default'` | `'disabled'` | `{ headers }` instead. */
     | boolean
     /** @deprecated Use `{ headers }` instead. */
     | Record<string, string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,7 +239,7 @@ export interface UserClaims {
  * }
  *
  * // No auth required, CORS disabled
- * const config: WithSupabaseConfig = { auth: 'none', cors: false }
+ * const config: WithSupabaseConfig = { auth: 'none', cors: 'none' }
  * ```
  *
  * @category Types
@@ -270,16 +270,27 @@ export interface WithSupabaseConfig {
   /**
    * CORS configuration for the `withSupabase` wrapper.
    *
-   * - `true` (default) — uses `@supabase/supabase-js` default CORS headers.
-   * - `false` — disables CORS handling entirely.
-   * - `Record<string, string>` — custom CORS headers.
+   * - `'default'` — uses `@supabase/supabase-js` default CORS headers.
+   * - `'none'` — disables CORS handling entirely.
+   * - `{ headers }` — custom CORS headers.
+   *
+   * The boolean (`true`/`false`) and bare `Record<string, string>` forms are
+   * deprecated but still accepted for backward compatibility.
    *
    * @remarks Only applies to the top-level {@link withSupabase} wrapper.
-   * The Hono adapter handles CORS separately via Hono's own middleware.
+   * The adapters (Hono, H3, Elysia, NestJS) handle CORS separately via each
+   * framework's own middleware.
    *
-   * @defaultValue `true`
+   * @defaultValue `'default'`
    */
-  cors?: boolean | Record<string, string>
+  cors?:
+    | 'default'
+    | 'none'
+    | { headers: Record<string, string> }
+    /** @deprecated Use `'default'` | `'none'` | `{ headers }` instead. */
+    | boolean
+    /** @deprecated Use `{ headers }` instead. */
+    | Record<string, string>
 
   /**
    * Options forwarded to both internal `createClient()` calls.

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -98,6 +98,66 @@ describe('withSupabase', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 
+  describe('explicit cors shape', () => {
+    it("skips OPTIONS handling when cors is 'none'", async () => {
+      const handler = withSupabase(
+        { auth: 'none', env: baseEnv, cors: 'none' },
+        async () => Response.json({ ok: true }),
+      )
+
+      const req = new Request('http://localhost', { method: 'OPTIONS' })
+      const res = await handler(req)
+      // When CORS disabled, OPTIONS goes through normal flow
+      expect(res.status).toBe(200)
+    })
+
+    it("does not add CORS headers when cors is 'none'", async () => {
+      const handler = withSupabase(
+        { auth: 'none', env: baseEnv, cors: 'none' },
+        async () => Response.json({ ok: true }),
+      )
+
+      const req = new Request('http://localhost')
+      const res = await handler(req)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+
+    it('applies custom { headers } to the success response', async () => {
+      const handler = withSupabase(
+        {
+          auth: 'none',
+          env: baseEnv,
+          cors: { headers: { 'Access-Control-Allow-Origin': 'https://a.com' } },
+        },
+        async () => Response.json({ ok: true }),
+      )
+
+      const req = new Request('http://localhost')
+      const res = await handler(req)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+        'https://a.com',
+      )
+    })
+
+    it('applies custom { headers } to the error response', async () => {
+      const handler = withSupabase(
+        {
+          auth: 'user',
+          env: baseEnv,
+          cors: { headers: { 'Access-Control-Allow-Origin': 'https://a.com' } },
+        },
+        async () => Response.json({ ok: true }),
+      )
+
+      const req = new Request('http://localhost')
+      const res = await handler(req)
+      expect(res.status).toBe(401)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+        'https://a.com',
+      )
+    })
+  })
+
   describe('allow → auth deprecation', () => {
     beforeEach(() => {
       _resetAllowDeprecationWarned()

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -99,9 +99,9 @@ describe('withSupabase', () => {
   })
 
   describe('explicit cors shape', () => {
-    it("skips OPTIONS handling when cors is 'none'", async () => {
+    it("skips OPTIONS handling when cors is 'disabled'", async () => {
       const handler = withSupabase(
-        { auth: 'none', env: baseEnv, cors: 'none' },
+        { auth: 'none', env: baseEnv, cors: 'disabled' },
         async () => Response.json({ ok: true }),
       )
 
@@ -111,9 +111,9 @@ describe('withSupabase', () => {
       expect(res.status).toBe(200)
     })
 
-    it("does not add CORS headers when cors is 'none'", async () => {
+    it("does not add CORS headers when cors is 'disabled'", async () => {
       const handler = withSupabase(
-        { auth: 'none', env: baseEnv, cors: 'none' },
+        { auth: 'none', env: baseEnv, cors: 'disabled' },
         async () => Response.json({ ok: true }),
       )
 

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -1,4 +1,4 @@
-import { addCorsHeaders, buildCorsHeaders } from './cors.js'
+import { addCorsHeaders, buildCorsHeaders, isCorsDisabled } from './cors.js'
 import { createSupabaseContext } from './create-supabase-context.js'
 import type { SupabaseContext, WithSupabaseConfig } from './types.js'
 
@@ -32,7 +32,7 @@ export function withSupabase<Database = unknown>(
   handler: (req: Request, ctx: SupabaseContext<Database>) => Promise<Response>,
 ): (req: Request) => Promise<Response> {
   return async (req: Request) => {
-    if (config.cors !== false && req.method === 'OPTIONS') {
+    if (!isCorsDisabled(config.cors) && req.method === 'OPTIONS') {
       return new Response(null, {
         status: 204,
         headers: buildCorsHeaders(config.cors),
@@ -48,14 +48,16 @@ export function withSupabase<Database = unknown>(
         { message: error.message, code: error.code },
         {
           status: error.status,
-          headers: config.cors !== false ? buildCorsHeaders(config.cors) : {},
+          headers: !isCorsDisabled(config.cors)
+            ? buildCorsHeaders(config.cors)
+            : {},
         },
       )
     }
 
     const response = await handler(req, ctx)
 
-    if (config.cors !== false) {
+    if (!isCorsDisabled(config.cors)) {
       return addCorsHeaders(response, config.cors)
     }
     return response


### PR DESCRIPTION
Makes the `withSupabase` `cors` option an explicit shape (`'default' | 'disabled' | { headers }`) instead of the ambiguous `boolean | Record<string, string>`. The old forms remain accepted but are deprecated, so this is non-breaking. Addresses SDK-1149 from the API review report.

## What kind of change does this PR introduce?

Feature (API cleanup), plus docs and tests. Non-breaking.

## What is the current behavior?

`cors` accepts `boolean | Record<string, string>`:

- `true` (default) applies the standard supabase-js CORS headers
- `false` disables CORS handling
- a `Record<string, string>` sets custom headers

This mixes a boolean sentinel with a bare header hash under one field, which is hard to type, document, and evolve.

## What is the new behavior?

`cors` now accepts an explicit shape:

- `'default'` applies the standard supabase-js CORS headers (still the default)
- `'disabled'` disables CORS handling
- `{ headers }` sets custom headers

The old `boolean` and bare `Record<string, string>` forms are still accepted but marked `@deprecated` in the JSDoc, following the same pattern as the existing `allow` to `auth` deprecation. They can be removed in a future major.

Changes:

- `src/cors.ts`: widen the internal `CorsConfig` union, add an exported `isCorsDisabled()` predicate, and teach `buildCorsHeaders` to read the `{ headers }` shape (distinguished from a bare record via an `'headers' in config` check).
- `src/with-supabase.ts`: replace the three inline `cors !== false` checks with `isCorsDisabled(config.cors)`.
- `src/types.ts`: update the public `cors` field to the new union with deprecation tags, set `@defaultValue` to `'default'`, and refresh the JSDoc and inline example.
- Tests: extend `cors.test.ts` and `with-supabase.test.ts` with coverage for `'default'`, `'disabled'`, and `{ headers }`, plus a dedicated `isCorsDisabled` suite. Existing deprecated-form tests are kept.
- Docs: update `README.md` and `docs/getting-started.md` to lead with the new shape and note the deprecated forms.

## Additional context

CORS is only handled by the root `@supabase/server` export. All four adapters (Hono, H3, Elysia, NestJS) already do `Omit<WithSupabaseConfig, 'cors'>` and delegate CORS to their framework, so the widened union flows through unchanged and no adapter edits were needed.

Verification: `npm run typecheck`, `npm run lint`, and `npm test` (196 tests) all pass. Backward compatibility confirmed: `cors: false` and bare-record configs still compile (with a deprecation hint) and behave as before.