### PR TITLE
refactor: one shared contract for the upstream auth keys

### DIFF
--- a/src/core/read-upstream-auth.test.ts
+++ b/src/core/read-upstream-auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import type { AuthMode, SupabaseContext, UpstreamAuth } from '../types.js'
+import { readUpstreamAuth } from './read-upstream-auth.js'
+
+describe('readUpstreamAuth', () => {
+  it('reads an empty contract when no upstream has run', () => {
+    expect(readUpstreamAuth(undefined)).toEqual({})
+    expect(readUpstreamAuth(null)).toEqual({})
+  })
+
+  it('reads the keys an upstream seeded', () => {
+    expect(
+      readUpstreamAuth({ authMode: 'publishable', authKeyName: 'web' }),
+    ).toEqual({ authMode: 'publishable', authKeyName: 'web' })
+  })
+
+  it('tracks SupabaseContext, so renaming a key there breaks the readers', () => {
+    expectTypeOf<UpstreamAuth>().toEqualTypeOf<{
+      authMode?: AuthMode
+      authKeyName?: string
+    }>()
+    expectTypeOf<UpstreamAuth['authMode']>().toEqualTypeOf<
+      SupabaseContext['authMode'] | undefined
+    >()
+  })
+
+  it('rejects a key the client entries never read', () => {
+    const seeded = {
+      authMode: 'secret',
+      // @ts-expect-error the contract admits only the keys the entries read
+      authKeyname: 'cron',
+    } satisfies UpstreamAuth
+
+    expect(seeded.authMode).toBe('secret')
+  })
+})

--- a/src/core/read-upstream-auth.ts
+++ b/src/core/read-upstream-auth.ts
@@ -1,0 +1,15 @@
+import type { UpstreamAuth } from '../types.js'
+
+/**
+ * Read the auth identity an upstream middleware seeded onto the context.
+ *
+ * The sole place the context is narrowed to `UpstreamAuth`. The cast is
+ * unavoidable: the client entries declare no prerequisite, so the engine types
+ * their `ctx` as the empty upstream.
+ *
+ * Returns an empty object when no upstream has run — the standalone case,
+ * where the entries fall back to their default keys.
+ */
+export function readUpstreamAuth(ctx: unknown): UpstreamAuth {
+  return (ctx ?? {}) as UpstreamAuth
+}

--- a/src/middleware/admin-client/index.ts
+++ b/src/middleware/admin-client/index.ts
@@ -3,8 +3,9 @@ import type { Entry } from '@supabase/middleware'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 import { createAdminClient } from '../../core/create-admin-client.js'
+import { readUpstreamAuth } from '../../core/read-upstream-auth.js'
 import { CreateSupabaseClientError, EnvError, Errors } from '../../errors.js'
-import type { AuthMode, CreateAdminClientOptions } from '../../types.js'
+import type { CreateAdminClientOptions } from '../../types.js'
 
 /**
  * Configuration for {@link withSupabaseAdminClient} — the same environment and
@@ -18,12 +19,6 @@ export type WithSupabaseAdminClientConfig = Omit<
   'auth'
 >
 
-/** Auth keys an upstream `withSupabase` seeds onto the context. @internal */
-interface UpstreamAuth {
-  authMode?: AuthMode
-  authKeyName?: string
-}
-
 const base = defineMiddleware<
   'supabaseAdmin',
   WithSupabaseAdminClientConfig | void,
@@ -32,7 +27,7 @@ const base = defineMiddleware<
 >({
   key: 'supabaseAdmin',
   run: (config) => async (_req, ctx) => {
-    const upstream = (ctx ?? {}) as UpstreamAuth
+    const upstream = readUpstreamAuth(ctx)
     // Under `withSupabase`, use the secret key the request matched; standalone
     // (or in other modes), the default secret key.
     const keyName =

--- a/src/middleware/client/index.ts
+++ b/src/middleware/client/index.ts
@@ -4,8 +4,9 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 import { createContextClient } from '../../core/create-context-client.js'
 import { extractCredentials } from '../../core/extract-credentials.js'
+import { readUpstreamAuth } from '../../core/read-upstream-auth.js'
 import { CreateSupabaseClientError, EnvError, Errors } from '../../errors.js'
-import type { AuthMode, CreateContextClientOptions } from '../../types.js'
+import type { CreateContextClientOptions } from '../../types.js'
 
 /**
  * Configuration for {@link withSupabaseClient} — the same environment and
@@ -16,12 +17,6 @@ import type { AuthMode, CreateContextClientOptions } from '../../types.js'
  */
 export type WithSupabaseClientConfig = Omit<CreateContextClientOptions, 'auth'>
 
-/** Auth keys an upstream `withSupabase` seeds onto the context. @internal */
-interface UpstreamAuth {
-  authMode?: AuthMode
-  authKeyName?: string
-}
-
 const base = defineMiddleware<
   'supabase',
   WithSupabaseClientConfig | void,
@@ -30,7 +25,7 @@ const base = defineMiddleware<
 >({
   key: 'supabase',
   run: (config) => async (req, ctx) => {
-    const upstream = (ctx ?? {}) as UpstreamAuth
+    const upstream = readUpstreamAuth(ctx)
     const { token: bearer } = extractCredentials(req)
     // `sb_*` secrets ride the Authorization header alongside the apikey
     // header — never attach them as a user token.

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,3 +387,23 @@ export interface SupabaseContext<Database = unknown> {
    */
   authKeyName?: string
 }
+
+/**
+ * The auth identity a composing wrapper seeds onto the context for the client
+ * entries to mirror — the subset of {@link SupabaseContext} that
+ * `withSupabaseClient` and `withSupabaseAdminClient` read to pick the key a
+ * verified request already matched.
+ *
+ * Every field is optional: the client entries are usable standalone, where no
+ * upstream has run and the defaults apply. That is why these keys are absent
+ * from the entries' `In` — a declared prerequisite is mandatory, and this one
+ * is not.
+ *
+ * Seeding both keys takes a wrapper that writes the context directly, as
+ * `withSupabase` does; a `defineMiddleware` entry contributes exactly one key.
+ *
+ * @internal
+ */
+export type UpstreamAuth = Partial<
+  Pick<SupabaseContext, 'authMode' | 'authKeyName'>
+>

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -3,7 +3,11 @@ import { verifyAuth } from './core/verify-auth.js'
 import { AuthError, CreateSupabaseClientError, EnvError } from './errors.js'
 import { withSupabaseAdminClient } from './middleware/admin-client/index.js'
 import { withSupabaseClient } from './middleware/client/index.js'
-import type { SupabaseContext, WithSupabaseConfig } from './types.js'
+import type {
+  SupabaseContext,
+  UpstreamAuth,
+  WithSupabaseConfig,
+} from './types.js'
 import { isContext, seedContext } from '@supabase/middleware'
 import type { BaseContext, Entry } from '@supabase/middleware'
 
@@ -206,12 +210,17 @@ export function withSupabase<Database = unknown>(
       const baseContext = isContext(platformArg)
         ? platformArg
         : seedContext(platformArg)
+      // The client entries read these two keys back off the context;
+      // `satisfies` holds the seed to that shape without widening it.
+      const upstreamAuth = {
+        authMode: auth.authMode,
+        authKeyName: auth.keyName ?? undefined,
+      } satisfies UpstreamAuth
       response = await composed(req, {
         ...baseContext,
         userClaims: auth.userClaims,
         jwtClaims: auth.jwtClaims,
-        authMode: auth.authMode,
-        authKeyName: auth.keyName ?? undefined,
+        ...upstreamAuth,
       })
     } catch (e) {
       // Client construction failures keep their historical response shape:


### PR DESCRIPTION
`withSupabaseClient` and `withSupabaseAdminClient` each declared a private copy of the auth keys they read off the context, and each reached them through its own cast. Nothing tied either copy to the context type that declares those keys, so renaming one degraded both readers to their default-key path, silently using the wrong credential under named-key
secret and publishable modes.

Derive the contract from `SupabaseContext` instead, read it through a single helper, and mark `withSupabase`'s seed with `satisfies` so the writer is checked against the same type as the readers.

The keys stay out of the entries' `In`: a declared prerequisite is mandatory, and these are optional so the entries remain usable standalone. The type stays internal, an entry contributes one `ctx` key, so no third-party middleware can seed both of these anyway.