### PR TITLE
docs: state that withClaims is not an auth gate

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -166,6 +166,46 @@ Defaults to `auth: 'user'` when config is omitted.
 
 ---
 
+## @supabase/server/middleware/claims
+
+### withClaims
+
+```ts
+const withClaims: Middleware<
+  'jwtClaims',
+  WithClaimsConfig | void,
+  Record<never, never>,
+  JWTClaims | null
+>
+```
+
+Contributes `ctx.jwtClaims` by verifying the caller's Bearer token against the project JWKS. This is the same verification core `withSupabase` uses for its `user` auth mode.
+
+Behavior:
+
+- No `Authorization: Bearer` token, or an `sb_*` API key in that position: contributes `null` and the request proceeds as anonymous.
+- Token present but invalid: short-circuits with a 401 and `{ message, code: 'INVALID_CREDENTIALS' }`.
+- Token present but no JWKS configured: short-circuits with a 500 and `{ message, code: 'ENV_ERROR' }`. Verification is required; the middleware has no decode-only mode.
+
+`withClaims` is not an auth gate. It never rejects a request that has no token, so `[withClaims(), withSupabaseClient()]` is not the composable form of `withSupabase({ auth: 'user' })` and accepts anonymous callers. To require an authenticated caller, gate with `withSupabase({ auth: 'user' })` and compose further middleware through its `middleware` option. A host that takes an entries array can wrap it as the sole entry:
+
+```ts
+const entry = (h: (req: Request, ctx: object) => Promise<Response>) =>
+  withSupabase({ auth: 'user', cors: 'disabled' }, h)
+```
+
+### WithClaimsConfig
+
+```ts
+interface WithClaimsConfig {
+  jwks?: JSONWebKeySet | URL
+}
+```
+
+Defaults to `SUPABASE_JWKS` (inline JSON) or `SUPABASE_JWKS_URL` (https endpoint) from the environment.
+
+---
+
 ## @supabase/server/middleware/postgres
 
 ### withPostgresClient

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -158,6 +158,8 @@ Order matters. `withPostgresClient` before `withClaims` is a compile-time error:
 middleware-prereq: key 'jwtClaims' is not yet on the context (check ordering)
 ```
 
+`withClaims` is not an auth gate. It contributes claims when a token is present, and `null` when one is not. The standalone pipeline above therefore also serves anonymous callers, whose queries run as `anon`. To require an authenticated caller, use the `withSupabase` form: `auth: 'user'` rejects token-less requests with a 401 before the handler runs.
+
 ## Table grants
 
 Queries run as `authenticated` or `anon`, and on current Supabase projects new tables grant those roles nothing. RLS policies are not enough on their own — a policy filters rows the role is already allowed to touch.

--- a/src/middleware/claims/index.ts
+++ b/src/middleware/claims/index.ts
@@ -41,6 +41,20 @@ export interface WithClaimsConfig {
  * - Token present but no JWKS configured → short-circuits with a 500 —
  *   verification is not optional; there is no decode-only mode.
  *
+ * `withClaims` is not an auth gate. It never rejects a request that has no
+ * token. A pipeline like `[withClaims(), withSupabaseClient()]` accepts
+ * anonymous callers and is not the composable form of
+ * `withSupabase({ auth: 'user' })`, which rejects token-less requests with
+ * a 401. To require an authenticated caller, gate with
+ * `withSupabase({ auth: 'user' })` and compose further middleware through
+ * its `middleware` option. A host that takes an entries array can wrap it
+ * as the sole entry:
+ *
+ * ```ts
+ * const entry = (h: (req: Request, ctx: object) => Promise<Response>) =>
+ *   withSupabase({ auth: 'user', cors: 'disabled' }, h)
+ * ```
+ *
  * @example Standalone pipeline
  * ```ts
  * import { pipeline } from '@supabase/middleware'


### PR DESCRIPTION
`withClaims` never rejects a request that has no token, so `[withClaims(), withSupabaseClient()]` reads like the composable form of `withSupabase({ auth: 'user' })` but accepts anonymous callers, and the mistake is silent: it compiles and passes a logged-in smoke test. This PR makes the docs say so before first publish: an explicit callout in the `withClaims` docstring, a note in the standalone pipeline section of `docs/postgres.md`, and a new `middleware/claims` section in the API reference, each pointing at `withSupabase({ auth: 'user' })` as the actual gate. The wrapped-entry snippet is the form verified to typecheck under this repo's strict config; the bare wrapper from SDK-1596 conflicts with typed entries placed after it in a pipeline. Docs only, no behavior change; best merged after #124 so the gate recommendation never sits ahead of the lazy admin client fix.