### PR TITLE
fix: require node >=22 to match @supabase/middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "skills"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "scripts": {


### PR DESCRIPTION
Raises `engines.node` from `>=20` to `>=22` so the declared floor matches `@supabase/middleware`, a hard dependency since #88 that already requires Node `>=22`. Without this, 1.5.0 would install with EBADENGINE warnings on npm/pnpm and fail on Yarn 1 for Node 20 users, then break at runtime anyway.

Non-breaking because no working configuration is lost: the dependency tree already enforces the `>=22` floor transitively, so this change only makes the declaration match reality. Node 20 has also been end-of-life since April 2026.