### PR TITLE
fix: attach error listeners to pooled pg connections

### DIFF
--- a/src/core/postgres-pool.test.ts
+++ b/src/core/postgres-pool.test.ts
@@ -1,0 +1,35 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it } from 'vitest'
+
+import { getPool } from './postgres-pool.js'
+
+// Constructing a pg.Pool opens no connections, so the real Pool class is safe
+// here — and it is the real class whose EventEmitter semantics matter: an
+// 'error' emitted with zero listeners throws out of emit() and, from a live
+// socket, takes down the whole process. Each test uses a distinct connection
+// string because the pool cache is keyed by it and lives for the process.
+
+describe('getPool error hardening', () => {
+  it('survives an error from an idle pooled connection', () => {
+    const pool = getPool('postgresql://pool-error@localhost:5432/db')
+    expect(pool.listenerCount('error')).toBeGreaterThan(0)
+    expect(() => pool.emit('error', new Error('backend died'))).not.toThrow()
+  })
+
+  it('survives an error from a checked-out client with no query in flight', () => {
+    const pool = getPool('postgresql://client-error@localhost:5432/db')
+    // pg emits 'connect' on the pool for every client it creates; the client
+    // itself must end up with an 'error' listener, because a pool-level
+    // listener does not cover a client that errors while checked out.
+    const client = new EventEmitter()
+    pool.emit('connect', client)
+    expect(client.listenerCount('error')).toBeGreaterThan(0)
+    expect(() => client.emit('error', new Error('backend died'))).not.toThrow()
+  })
+
+  it('returns the cached pool for a repeated connection string', () => {
+    const url = 'postgresql://cached@localhost:5432/db'
+    expect(getPool(url)).toBe(getPool(url))
+  })
+})

--- a/src/core/postgres-pool.ts
+++ b/src/core/postgres-pool.ts
@@ -89,6 +89,25 @@ export function getPool(connectionString: string): pg.Pool {
   let pool = pools.get(connectionString)
   if (!pool) {
     pool = new Pool({ connectionString, max: 4 })
+    // A backend can die under any pooled connection at any time — pooler
+    // restart, failover, idle-connection reap. pg surfaces that as an 'error'
+    // event on the pool (idle client) or on the client itself (checked out
+    // with no query in flight), and an 'error' event with no listener is
+    // fatal to the whole process. Both listeners must exist so a dropped
+    // connection stays a per-request failure: the in-flight query rejects
+    // and the pool discards the dead client.
+    pool.on('error', (e) => {
+      console.error(
+        `[@supabase/server] postgres pool: idle connection lost (discarded): ${e.message}`,
+      )
+    })
+    pool.on('connect', (client) => {
+      client.on('error', (e) => {
+        console.error(
+          `[@supabase/server] postgres pool: connection lost: ${e.message}`,
+        )
+      })
+    })
     pools.set(connectionString, pool)
   }
   return pool

--- a/src/middleware/postgres-admin/index.test.ts
+++ b/src/middleware/postgres-admin/index.test.ts
@@ -15,11 +15,15 @@ const h = vi.hoisted(() => {
   return { issued, params, pooled, poolQuery, connect }
 })
 
-vi.mock('pg', () => {
-  class Pool {
+vi.mock('pg', async () => {
+  const { EventEmitter } = await import('node:events')
+  // Real pg pools are EventEmitters; getPool attaches 'error' and 'connect'
+  // listeners on construction, so the mock must accept them.
+  class Pool extends EventEmitter {
     query = h.poolQuery
     connect = h.connect
     constructor(config: { connectionString: string }) {
+      super()
       h.pooled.push(config.connectionString)
     }
   }

--- a/src/middleware/postgres/index.test.ts
+++ b/src/middleware/postgres/index.test.ts
@@ -17,10 +17,14 @@ const h = vi.hoisted(() => {
   return { issued, params, pooled, clientQuery, release, connect }
 })
 
-vi.mock('pg', () => {
-  class Pool {
+vi.mock('pg', async () => {
+  const { EventEmitter } = await import('node:events')
+  // Real pg pools are EventEmitters; getPool attaches 'error' and 'connect'
+  // listeners on construction, so the mock must accept them.
+  class Pool extends EventEmitter {
     connect = h.connect
     constructor(config: { connectionString: string }) {
+      super()
       h.pooled.push(config.connectionString)
     }
   }


### PR DESCRIPTION
## What this fixes

`getPool` creates the shared `pg.Pool` without any `'error'` listeners. When a backend dies under a pooled connection (pooler restart, failover, idle-connection reap), node-postgres emits `'error'` with no listener attached, and Node treats an unheard `'error'` event as fatal: the whole process exits. One dropped connection takes down every in-flight request on the host instead of failing a single query. `withPostgresClient` and `withPostgresAdminClient` share this pool, so both are affected.

The error surfaces on two different emitters, and both need a listener:

- the pool, for a client sitting idle in the pool
- the client itself, for a client checked out with no query in flight (for example between the statements of the per-query transaction)

A query that is mid-flight when the backend dies already rejects its promise and flows through the existing error handling. The two idle windows were the fatal ones.

## The fix

`getPool` now attaches an `'error'` listener on the pool and, via the pool's `'connect'` event, on every client it creates. Each logs a `[@supabase/server]` prefixed line and lets the pool discard the dead connection, so a dropped connection degrades to a per-request failure and the process keeps serving.

## Testing

- New unit tests in `src/core/postgres-pool.test.ts` use the real `pg.Pool`, which opens no connections on construction: the pool survives `emit('error')`, a client passed through `'connect'` gets its own listener and survives, and the cache still returns one pool per connection string.
- The `pg` mocks in the two middleware test files now extend `EventEmitter`, matching the real class.
- Verified end to end against a live project through Supavisor in transaction mode: under mixed load with repeated `pg_terminate_backend` waves, processes previously died on the first wave. With this change, failures degrade to clean per-request 500s and traffic recovers immediately.