### PR TITLE
fix: pass withSupabase error responses through middleware seam

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,6 +21,8 @@ Wraps a fetch handler with auth, CORS, and client creation. Returns a `(req: Req
 - Verifies credentials per `config.auth`
 - Returns JSON error response on auth failure
 - Adds CORS headers to all responses
+- Composes a `middleware: [...]` array of entries after auth and client creation; entries receive `ctx.supabase`, `ctx.jwtClaims`, and the rest already present
+- Auth and client-creation error responses pass through the array's response phase, so a generator entry can decorate them (same-status only; drained bodies are rebuilt; a throwing entry is logged and the response returned undecorated). A middleware that must answer unauthenticated requests wraps around `withSupabase` instead — see [Placement](#placement).
 
 ### createSupabaseContext
 
@@ -389,6 +391,68 @@ interface WithPostgresAdminClientConfig {
 ```
 
 Defaults to the `SUPABASE_DB_URL` environment variable.
+
+---
+
+## @supabase/server/oauth-protected-resource
+
+### withOAuthProtectedResource
+
+```ts
+const withOAuthProtectedResource: Middleware<
+  'oauthProtectedResource',
+  OAuthProtectedResourceConfig | undefined,
+  Record<never, never>,
+  OAuthProtectedResourceContribution
+>
+```
+
+Wraps a handler with OAuth 2.1 Protected Resource behavior (RFC 9728):
+
+- Serves the Protected Resource Metadata document at `GET {resource}/oauth-protected-resource`, including a permissive preflight for that route that allows `mcp-protocol-version`
+- Enriches a downstream `401` with `WWW-Authenticate: Bearer resource_metadata="…"` unless the response already carries one
+- Passes every other request through unchanged
+
+Contributes `ctx.oauthProtectedResource` (the resolved metadata URL) downstream. Zero-config on Supabase Edge Functions; elsewhere `resourceServer` is required and `authorizationServer` falls back to `SUPABASE_URL`-derived values (each throws an `EnvError` when unresolvable).
+
+### Placement
+
+Discovery and preflight are answered from the request phase, before any authentication, so the middleware wraps **around** `withSupabase` — outside the auth gate:
+
+```ts
+withOAuthProtectedResource(config, withSupabase({ auth: 'user' }, handler))
+```
+
+or, as a flat pipeline:
+
+```ts
+pipeline(
+  [withOAuthProtectedResource(config)],
+  withSupabase({ auth: 'user' }, handler),
+)
+```
+
+Inside `withSupabase`'s `middleware` array the auth gate runs first and answers discovery and preflight itself, so only part of the behavior works there:
+
+| Behavior                                        | Wrap / `pipeline` | Inside `middleware: [...]`                                                                   |
+| ----------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| `WWW-Authenticate` on `401` responses           | Yes               | Yes                                                                                          |
+| Discovery (`GET …/oauth-protected-resource`)    | Yes               | No — the auth gate returns `401 MISSING_CREDENTIALS` first                                   |
+| Metadata-route preflight `mcp-protocol-version` | Yes               | No — the generic preflight answers first; workaround: add the header via `cors: { headers }` |
+| Authenticated requests                          | Yes               | Yes                                                                                          |
+
+Array placement emits a once-per-process `console.warn` naming the wrap form.
+
+### OAuthProtectedResourceConfig
+
+```ts
+interface OAuthProtectedResourceConfig {
+  resourceServer?: UrlOption
+  authorizationServer?: UrlOption
+}
+```
+
+Both options accept a fixed string or a function of the request. `fromSupabaseUrl(url)` builds an `authorizationServer` for a specific project.
 
 ---
 

--- a/src/core/composition-marker.ts
+++ b/src/core/composition-marker.ts
@@ -1,0 +1,11 @@
+/**
+ * Marks a context assembled by `withSupabase` for the entries of its
+ * `middleware` array. A middleware that behaves differently inside that
+ * composition (a placement warning, for example) tests for this key instead
+ * of duck-typing on context key names, which an unrelated upstream
+ * middleware could collide with. Symbol keys survive the engine's context
+ * spreads.
+ *
+ * @internal
+ */
+export const withSupabaseCtxMarker = Symbol('withSupabase.middlewareArray')

--- a/src/oauth-protected-resource/with-oauth-protected-resource.ts
+++ b/src/oauth-protected-resource/with-oauth-protected-resource.ts
@@ -42,6 +42,18 @@ export interface OAuthProtectedResourceConfig {
   authorizationServer?: UrlOption
 }
 
+let warnedArrayPlacement = false
+
+/**
+ * Test-only helper to reset the one-shot array-placement warning latch so
+ * each test can independently observe the warning.
+ *
+ * @internal
+ */
+export function _resetOAuthPlacementWarned(): void {
+  warnedArrayPlacement = false
+}
+
 /**
  * Wraps a request handler with OAuth 2.1 Protected Resource behavior (RFC 9728).
  *
@@ -65,6 +77,13 @@ export interface OAuthProtectedResourceConfig {
  * downstream context. Nested under `withSupabase`, the key is typed on the
  * handler's `ctx` when the outermost call is anchored with
  * `satisfies FetchHandler` — see `withSupabase`'s type note.
+ *
+ * Compose the wrap form shown below, or its flat spelling —
+ * `pipeline([withOAuthProtectedResource(config)], withSupabase(config, handler))`
+ * — which folds to the same composition. Inside `withSupabase`'s `middleware`
+ * array the auth gate answers discovery and preflight requests before this
+ * middleware sees them; only the `WWW-Authenticate` enrichment survives
+ * there, and a runtime warning is emitted.
  *
  * @category Middleware
  *
@@ -122,7 +141,18 @@ export const withOAuthProtectedResource: Middleware<
 >({
   key: 'oauthProtectedResource',
   run: (config) =>
-    async function* (req) {
+    async function* (req, ctx) {
+      // `userClaims` / `authMode` on the upstream context mean this middleware
+      // sits inside `withSupabase`'s post-auth array, where the auth gate
+      // answers discovery and preflight requests before this middleware can
+      // serve them. The supported placement wraps `withSupabase`.
+      if (!warnedArrayPlacement && ('userClaims' in ctx || 'authMode' in ctx)) {
+        warnedArrayPlacement = true
+        console.warn(
+          'withOAuthProtectedResource is inside a withSupabase middleware array, where OAuth discovery and CORS preflight cannot be served. Wrap it around withSupabase instead: withOAuthProtectedResource(config, withSupabase(config, handler)).',
+        )
+      }
+
       const url = new URL(req.url)
       // The metadata document lives at `{resource}/oauth-protected-resource`.
       // Matching on the suffix keeps this working wherever the endpoint is

--- a/src/oauth-protected-resource/with-oauth-protected-resource.ts
+++ b/src/oauth-protected-resource/with-oauth-protected-resource.ts
@@ -1,6 +1,7 @@
 import { defineMiddleware } from '@supabase/middleware'
 import type { Middleware } from '@supabase/middleware'
 
+import { withSupabaseCtxMarker } from '../core/composition-marker.js'
 import { resourceMetadataResponse } from './responses.js'
 import { getAuthUrl, getResourceMetadataUrl, getResourceUrl } from './url.js'
 import type { UrlOption } from './url.js'
@@ -142,11 +143,11 @@ export const withOAuthProtectedResource: Middleware<
   key: 'oauthProtectedResource',
   run: (config) =>
     async function* (req, ctx) {
-      // `userClaims` / `authMode` on the upstream context mean this middleware
-      // sits inside `withSupabase`'s post-auth array, where the auth gate
-      // answers discovery and preflight requests before this middleware can
-      // serve them. The supported placement wraps `withSupabase`.
-      if (!warnedArrayPlacement && ('userClaims' in ctx || 'authMode' in ctx)) {
+      // The marker identifies a context assembled by `withSupabase` for its
+      // post-auth array, where the auth gate answers discovery and preflight
+      // requests before this middleware can serve them. The supported
+      // placement wraps `withSupabase`.
+      if (!warnedArrayPlacement && withSupabaseCtxMarker in ctx) {
         warnedArrayPlacement = true
         console.warn(
           'withOAuthProtectedResource is inside a withSupabase middleware array, where OAuth discovery and CORS preflight cannot be served. Wrap it around withSupabase instead: withOAuthProtectedResource(config, withSupabase(config, handler)).',

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
-import { defineMiddleware, getEnv } from '@supabase/middleware'
+import { defineMiddleware, getEnv, pipeline } from '@supabase/middleware'
 import type { Entry, FetchHandler } from '@supabase/middleware'
 
 import { _resetAllowDeprecationWarned } from './core/utils/deprecation.js'
@@ -903,6 +903,60 @@ describe('withSupabase error responses through middleware', () => {
     expect(seen).toEqual([500])
   })
 
+  it('keeps entry state across error-path requests', async () => {
+    let calls = 0
+    const withCounter = defineMiddleware<
+      'counter',
+      undefined,
+      Record<never, never>,
+      number
+    >({
+      key: 'counter',
+      run: () => {
+        let seen = 0
+        return async () => {
+          seen += 1
+          calls = seen
+          return { counter: seen }
+        }
+      },
+    })
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withCounter()] },
+      async () => Response.json({ ok: true }),
+    )
+    await handler(new Request('http://localhost'))
+    await handler(new Request('http://localhost'))
+    expect(calls).toBe(2)
+  })
+
+  it('restores error CORS headers on a same-status replacement', async () => {
+    const withReplace = defineMiddleware<
+      'replace',
+      undefined,
+      Record<never, never>,
+      true
+    >({
+      key: 'replace',
+      run: () =>
+        async function* () {
+          const res = yield { replace: true as const }
+          return new Response('shaped', { status: res.status })
+        },
+    })
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withReplace()] },
+      async () => Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('shaped')
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(res.headers.get('Access-Control-Expose-Headers')).toContain(
+      ErrorCodeHeader,
+    )
+  })
+
   it('leaves responses untouched when the array is empty', async () => {
     const handler = withSupabase({ auth: 'user', env: baseEnv }, async () =>
       Response.json({ ok: true }),
@@ -980,6 +1034,26 @@ describe('withOAuthProtectedResource array-placement warning', () => {
     await handler(new Request('http://localhost/functions/v1/mcp'))
     await handler(new Request('http://localhost/functions/v1/mcp'))
     expect(placementWarnings(warn)).toHaveLength(1)
+    warn.mockRestore()
+  })
+
+  it('does not warn when an unrelated upstream entry contributes userClaims', async () => {
+    const withFakeClaims = defineMiddleware<
+      'userClaims',
+      undefined,
+      Record<never, never>,
+      null
+    >({
+      key: 'userClaims',
+      run: () => async () => ({ userClaims: null }),
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handler = pipeline(
+      [withFakeClaims(), withOAuthProtectedResource(oauthCfg)],
+      async () => new Response('ok'),
+    )
+    await handler(new Request('http://localhost/functions/v1/mcp'))
+    expect(placementWarnings(warn)).toHaveLength(0)
     warn.mockRestore()
   })
 

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -14,7 +14,10 @@ import {
 import type { WithSupabaseConfig } from './types.js'
 import { withClaims } from './middleware/claims/index.js'
 import { withPostgresClient } from './middleware/postgres/index.js'
-import { withOAuthProtectedResource } from './oauth-protected-resource/with-oauth-protected-resource.js'
+import {
+  withOAuthProtectedResource,
+  _resetOAuthPlacementWarned,
+} from './oauth-protected-resource/with-oauth-protected-resource.js'
 import { withSupabase } from './with-supabase.js'
 
 const baseEnv = {
@@ -775,5 +778,213 @@ describe('type guarantees (tsc-verified)', () => {
       },
     )
     void _handler
+  })
+})
+
+describe('withSupabase error responses through middleware', () => {
+  const stampProbe = () => {
+    const seen: number[] = []
+    const withStamp = defineMiddleware<
+      'stamp',
+      undefined,
+      Record<never, never>,
+      true
+    >({
+      key: 'stamp',
+      run: () =>
+        async function* () {
+          const res = yield { stamp: true as const }
+          seen.push(res.status)
+          res.headers.set('x-stamped', 'yes')
+          return res
+        },
+    })
+    return { withStamp, seen }
+  }
+
+  it('routes auth-failure responses through the response phase', async () => {
+    const { withStamp, seen } = stampProbe()
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withStamp()] },
+      async () => Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(401)
+    expect(res.headers.get('x-stamped')).toBe('yes')
+    expect(seen).toEqual([401])
+  })
+
+  it('discards a middleware response of a different status on the error path', async () => {
+    const withHijack = defineMiddleware<
+      'hijack',
+      undefined,
+      Record<never, never>,
+      true
+    >({
+      key: 'hijack',
+      run: () => async () => new Response('cached', { status: 200 }),
+    })
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withHijack()] },
+      async () => Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(401)
+    expect(await res.text()).not.toBe('cached')
+  })
+
+  it('falls back to the plain error response when an entry throws on the error path', async () => {
+    const withBoom = defineMiddleware<
+      'boom',
+      undefined,
+      Record<never, never>,
+      true
+    >({
+      key: 'boom',
+      run: () => async (_req, ctx) => {
+        void (
+          ctx as { supabase: { from: (t: string) => unknown } }
+        ).supabase.from('items')
+        return { boom: true as const }
+      },
+    })
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withBoom()] },
+      async () => Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(401)
+  })
+
+  it('seeds null claims on the error path', async () => {
+    let observed: unknown = 'unset'
+    const withProbe = defineMiddleware<
+      'probe',
+      undefined,
+      Record<never, never>,
+      true
+    >({
+      key: 'probe',
+      run: () => async (_req, ctx) => {
+        observed = (ctx as { jwtClaims?: unknown }).jwtClaims
+        return { probe: true as const }
+      },
+    })
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withProbe()] },
+      async () => Response.json({ ok: true }),
+    )
+    await handler(new Request('http://localhost'))
+    expect(observed).toBeNull()
+  })
+
+  it('routes client-construction failures through the response phase', async () => {
+    const { withStamp, seen } = stampProbe()
+    const handler = withSupabase(
+      {
+        auth: 'none',
+        env: { ...baseEnv, publishableKeys: {} },
+        middleware: [withStamp()],
+      },
+      async () => Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(500)
+    expect(res.headers.get('x-stamped')).toBe('yes')
+    expect(seen).toEqual([500])
+  })
+
+  it('leaves responses untouched when the array is empty', async () => {
+    const handler = withSupabase({ auth: 'user', env: baseEnv }, async () =>
+      Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('withOAuthProtectedResource inside the middleware array', () => {
+  const oauthCfg = {
+    resourceServer: 'http://localhost/functions/v1/mcp',
+    authorizationServer: 'https://test.supabase.co/auth/v1',
+  }
+
+  it('enriches an auth 401 with WWW-Authenticate', async () => {
+    const handler = withSupabase(
+      {
+        auth: 'user',
+        env: baseEnv,
+        middleware: [withOAuthProtectedResource(oauthCfg)],
+      },
+      async () => new Response('handler ran'),
+    )
+    const res = await handler(
+      new Request('http://localhost/functions/v1/mcp', { method: 'POST' }),
+    )
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toContain('resource_metadata')
+  })
+
+  it('does not serve discovery from inside the array (wrap form owns discovery)', async () => {
+    const handler = withSupabase(
+      {
+        auth: 'user',
+        env: baseEnv,
+        middleware: [withOAuthProtectedResource(oauthCfg)],
+      },
+      async () => new Response('handler ran'),
+    )
+    const res = await handler(
+      new Request(
+        'http://localhost/functions/v1/mcp/.well-known/oauth-protected-resource',
+      ),
+    )
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('withOAuthProtectedResource array-placement warning', () => {
+  const oauthCfg = {
+    resourceServer: 'http://localhost/functions/v1/mcp',
+    authorizationServer: 'https://test.supabase.co/auth/v1',
+  }
+
+  beforeEach(() => {
+    _resetOAuthPlacementWarned()
+  })
+
+  const placementWarnings = (warn: { mock: { calls: unknown[][] } }) =>
+    warn.mock.calls.filter(([msg]) =>
+      String(msg).includes('withOAuthProtectedResource'),
+    )
+
+  it('warns once when placed inside a withSupabase middleware array', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handler = withSupabase(
+      {
+        auth: 'none',
+        env: baseEnv,
+        middleware: [withOAuthProtectedResource(oauthCfg)],
+      },
+      async () => new Response('ok'),
+    )
+    await handler(new Request('http://localhost/functions/v1/mcp'))
+    await handler(new Request('http://localhost/functions/v1/mcp'))
+    expect(placementWarnings(warn)).toHaveLength(1)
+    warn.mockRestore()
+  })
+
+  it('does not warn in the wrap form', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handler = withOAuthProtectedResource(
+      oauthCfg,
+      withSupabase(
+        { auth: 'none', env: baseEnv },
+        async () => new Response('ok'),
+      ),
+    )
+    await handler(new Request('http://localhost/functions/v1/mcp'))
+    expect(placementWarnings(warn)).toHaveLength(0)
+    warn.mockRestore()
   })
 })

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -955,6 +955,35 @@ describe('withSupabase error responses through middleware', () => {
     expect(res.headers.get('Access-Control-Expose-Headers')).toContain(
       ErrorCodeHeader,
     )
+    expect(res.headers.get(ErrorCodeHeader)).toBe(MissingCredentialsError)
+    expect(res.headers.get('Content-Type')).not.toContain('application/json')
+  })
+
+  it('rebuilds the body when an entry drains it for logging', async () => {
+    const withDrain = defineMiddleware<
+      'drain',
+      undefined,
+      Record<never, never>,
+      true
+    >({
+      key: 'drain',
+      run: () =>
+        async function* () {
+          const res = yield { drain: true as const }
+          await res.text()
+          res.headers.set('x-logged', 'yes')
+          return res
+        },
+    })
+    const handler = withSupabase(
+      { auth: 'user', env: baseEnv, middleware: [withDrain()] },
+      async () => Response.json({ ok: true }),
+    )
+    const res = await handler(new Request('http://localhost'))
+    expect(res.status).toBe(401)
+    expect(res.headers.get('x-logged')).toBe('yes')
+    const body = await res.json()
+    expect(body.code).toBe(MissingCredentialsError)
   })
 
   it('leaves responses untouched when the array is empty', async () => {

--- a/src/with-supabase.test.ts
+++ b/src/with-supabase.test.ts
@@ -852,12 +852,19 @@ describe('withSupabase error responses through middleware', () => {
       { auth: 'user', env: baseEnv, middleware: [withBoom()] },
       async () => Response.json({ ok: true }),
     )
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const res = await handler(new Request('http://localhost'))
     expect(res.status).toBe(401)
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('threw while the error response'),
+      expect.any(TypeError),
+    )
+    error.mockRestore()
   })
 
-  it('seeds null claims on the error path', async () => {
-    let observed: unknown = 'unset'
+  it('seeds null claims and no auth mode on the error path', async () => {
+    let observedClaims: unknown = 'unset'
+    let observedAuthMode: unknown = 'unset'
     const withProbe = defineMiddleware<
       'probe',
       undefined,
@@ -866,7 +873,8 @@ describe('withSupabase error responses through middleware', () => {
     >({
       key: 'probe',
       run: () => async (_req, ctx) => {
-        observed = (ctx as { jwtClaims?: unknown }).jwtClaims
+        observedClaims = (ctx as { jwtClaims?: unknown }).jwtClaims
+        observedAuthMode = (ctx as { authMode?: unknown }).authMode
         return { probe: true as const }
       },
     })
@@ -875,7 +883,8 @@ describe('withSupabase error responses through middleware', () => {
       async () => Response.json({ ok: true }),
     )
     await handler(new Request('http://localhost'))
-    expect(observed).toBeNull()
+    expect(observedClaims).toBeNull()
+    expect(observedAuthMode).toBeUndefined()
   })
 
   it('routes client-construction failures through the response phase', async () => {

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -106,6 +106,15 @@ export function withSupabase<
  * on top. (This is the server leg of a Plugin: the package's middleware goes
  * here; its client namespace goes in `createClient`'s `plugins` array.)
  *
+ * When `withSupabase` itself produces a response — an auth failure or a
+ * client-construction failure — that response passes through the array's
+ * response phase, so a generator entry can decorate it (headers, logging,
+ * timing). On that path the context carries `userClaims`/`jwtClaims` as
+ * verified (or `null` on auth failure) and no Supabase clients, and a
+ * replacement response of a different status is discarded. A middleware that
+ * must *answer* unauthenticated requests — OAuth discovery, custom
+ * preflight — wraps around `withSupabase` instead of sitting in the array.
+ *
  * > **Alpha.** The `middleware` option is in alpha, alongside
  * > `@supabase/middleware` 0.x. Its shape may change between 0.x releases.
  *
@@ -202,6 +211,32 @@ export function withSupabase<Database = unknown>(
       }
     }
 
+    // withSupabase's own responses (auth failure, client-construction
+    // failure) pass through the user middleware's response phase, so a
+    // response-seam entry can decorate them on the way out. The engine's
+    // seam is a resumed generator, so entries' request phases run too — on
+    // the auth-failure path the context carries null claims and no Supabase
+    // clients. The composed result is kept only when it has the same status
+    // as the original: the array may shape an error response, never
+    // commandeer it. An entry that throws here falls back to the original.
+    const respondThroughMiddleware = async (
+      original: Response,
+      ctx: object,
+    ): Promise<Response> => {
+      const entries = config.middleware ?? []
+      if (entries.length === 0) return original
+      const folded = entries.reduceRight<AnyHandler>(
+        (h, entry) => entry(h),
+        async () => original,
+      )
+      try {
+        const result = await folded(req, ctx)
+        return result.status === original.status ? result : original
+      } catch {
+        return original
+      }
+    }
+
     if (!isCorsDisabled(config.cors) && req.method === 'OPTIONS') {
       return new Response(null, {
         status: 204,
@@ -209,17 +244,35 @@ export function withSupabase<Database = unknown>(
       })
     }
 
+    // As the entry point, `platformArg` is the host env — seed a context from
+    // it (captured behind getEnv). Nested under another middleware, it's an
+    // already-seeded context: reuse it, or reseeding would clobber the platform
+    // env and drop upstream ctx keys.
+    const baseContext = isContext(platformArg)
+      ? platformArg
+      : seedContext(platformArg)
+
     const { data: auth, error } = await verifyAuth(req, {
       auth: config.auth,
       allow: config.allow,
       env: config.env,
     })
     if (error) {
-      return errorResponse(error, {
-        headers: errorHeaders(),
-        errors: config.errors,
-      })
+      return respondThroughMiddleware(
+        errorResponse(error, {
+          headers: errorHeaders(),
+          errors: config.errors,
+        }),
+        { ...baseContext, userClaims: null, jwtClaims: null },
+      )
     }
+
+    // The client entries read these two keys back off the context;
+    // `satisfies` holds the seed to that shape without widening it.
+    const upstreamAuth = {
+      authMode: auth.authMode,
+      authKeyName: auth.keyName ?? undefined,
+    } satisfies UpstreamAuth
 
     // Track whether the request has moved past the client entries: only
     // client-phase construction failures (the `supabase` entry) map to JSON
@@ -238,19 +291,6 @@ export function withSupabase<Database = unknown>(
 
     let response: Response
     try {
-      // As the entry point, `platformArg` is the host env — seed a context from
-      // it (captured behind getEnv). Nested under another middleware, it's an
-      // already-seeded context: reuse it, or reseeding would clobber the platform
-      // env and drop upstream ctx keys.
-      const baseContext = isContext(platformArg)
-        ? platformArg
-        : seedContext(platformArg)
-      // The client entries read these two keys back off the context;
-      // `satisfies` holds the seed to that shape without widening it.
-      const upstreamAuth = {
-        authMode: auth.authMode,
-        authKeyName: auth.keyName ?? undefined,
-      } satisfies UpstreamAuth
       response = await composed(req, {
         ...baseContext,
         userClaims: auth.userClaims,
@@ -277,10 +317,18 @@ export function withSupabase<Database = unknown>(
             ? e
             : null
       if (!mapped) throw e
-      return errorResponse(mapped, {
-        headers: errorHeaders(),
-        errors: config.errors,
-      })
+      return respondThroughMiddleware(
+        errorResponse(mapped, {
+          headers: errorHeaders(),
+          errors: config.errors,
+        }),
+        {
+          ...baseContext,
+          userClaims: auth.userClaims,
+          jwtClaims: auth.jwtClaims,
+          ...upstreamAuth,
+        },
+      )
     }
 
     if (!isCorsDisabled(config.cors)) {

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -14,8 +14,11 @@ import type {
   UpstreamAuth,
   WithSupabaseConfig,
 } from './types.js'
+import { withSupabaseCtxMarker } from './core/composition-marker.js'
 import { isContext, seedContext } from '@supabase/middleware'
 import type { BaseContext, Entry, ValidateEntries } from '@supabase/middleware'
+
+const originalResponseKey = Symbol('withSupabase.originalResponse')
 
 type AnyEntry = Entry<string, object, unknown>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -109,13 +112,18 @@ export function withSupabase<
  * When `withSupabase` itself produces a response — an auth failure or a
  * client-construction failure — that response passes through the array's
  * response phase, so a generator entry can decorate it (headers, logging,
- * timing). The auth-failure context carries `userClaims`/`jwtClaims` as
- * `null` and omits `authMode`, `authKeyName`, and the Supabase clients — no
- * caller was verified, so none of those exist. A replacement response of a
- * different status is discarded, and an entry that throws on this path is
- * logged and the response returned undecorated. A middleware that must
- * *answer* unauthenticated requests — OAuth discovery, custom preflight —
- * wraps around `withSupabase` instead of sitting in the array.
+ * timing). Entries' request phases run for these responses too — the seam
+ * is a resumed generator — so a side-effecting entry (rate limiting, audit
+ * logging) observes unauthenticated requests, with its state shared with
+ * the success path (the chain folds once). The auth-failure context carries
+ * `userClaims`/`jwtClaims` as `null` and omits `authMode`, `authKeyName`,
+ * and the Supabase clients — no caller was verified, so none of those
+ * exist. A replacement response of a different status is discarded; a
+ * same-status replacement keeps the error CORS headers where the entry set
+ * none of its own; and an entry that throws on this path is logged and the
+ * response returned undecorated. A middleware that must *answer*
+ * unauthenticated requests — OAuth discovery, custom preflight — wraps
+ * around `withSupabase` instead of sitting in the array.
  *
  * > **Alpha.** The `middleware` option is in alpha, alongside
  * > `@supabase/middleware` 0.x. Its shape may change between 0.x releases.
@@ -187,10 +195,22 @@ export function withSupabase<Database = unknown>(
       supabaseOptions: config.supabaseOptions,
     }) as AnyEntry,
   ]
-  // The user's middleware and handler fold once at wrap time.
+  // The user's middleware and handler fold once at wrap time — entry state
+  // (rate-limit counters, caches) lives in closures created here, so every
+  // request, including one carrying an error response, reaches the same
+  // entry instances. The terminal serves both paths: normally it is the
+  // user handler; when the context carries a response withSupabase built
+  // itself (auth failure, client-construction failure), the chain is
+  // re-entered only to shape that response, and the terminal returns it.
+  // A symbol key keeps the response off the entries' typed context and
+  // makes concurrent requests race-free (no shared slot).
+  const userTerminal: AnyHandler = (r, ctx) =>
+    originalResponseKey in ctx
+      ? Promise.resolve((ctx as Record<symbol, Response>)[originalResponseKey])
+      : handler(r, ctx)
   const userComposed = (config.middleware ?? []).reduceRight<AnyHandler>(
     (h, entry) => entry(h),
-    handler,
+    userTerminal,
   )
 
   return async (req: Request, platformArg?: unknown) => {
@@ -225,15 +245,24 @@ export function withSupabase<Database = unknown>(
       original: Response,
       ctx: object,
     ): Promise<Response> => {
-      const entries = config.middleware ?? []
-      if (entries.length === 0) return original
-      const folded = entries.reduceRight<AnyHandler>(
-        (h, entry) => entry(h),
-        async () => original,
-      )
+      if ((config.middleware ?? []).length === 0) return original
       try {
-        const result = await folded(req, ctx)
-        return result.status === original.status ? result : original
+        const result = await userComposed(req, {
+          ...ctx,
+          [withSupabaseCtxMarker]: true,
+          [originalResponseKey]: original,
+        })
+        if (result.status !== original.status) return original
+        if (result === original) return result
+        // A same-status replacement is a fresh Response, so the error CORS
+        // headers (and the exposed error-code header) are re-applied where
+        // the entry did not set its own values — a decorated 401 must stay
+        // readable cross-origin.
+        const restored = new Response(result.body, result)
+        for (const [key, value] of Object.entries(errorHeaders())) {
+          if (!restored.headers.has(key)) restored.headers.set(key, value)
+        }
+        return restored
       } catch (err) {
         console.error(
           'withSupabase: a middleware entry threw while the error response passed through the response phase; the response is returned undecorated. Entries on this path see null claims and no Supabase clients.',
@@ -302,6 +331,7 @@ export function withSupabase<Database = unknown>(
         userClaims: auth.userClaims,
         jwtClaims: auth.jwtClaims,
         ...upstreamAuth,
+        [withSupabaseCtxMarker]: true,
       })
     } catch (e) {
       // Client-phase construction failures map to JSON error responses:

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -109,11 +109,13 @@ export function withSupabase<
  * When `withSupabase` itself produces a response — an auth failure or a
  * client-construction failure — that response passes through the array's
  * response phase, so a generator entry can decorate it (headers, logging,
- * timing). On that path the context carries `userClaims`/`jwtClaims` as
- * verified (or `null` on auth failure) and no Supabase clients, and a
- * replacement response of a different status is discarded. A middleware that
- * must *answer* unauthenticated requests — OAuth discovery, custom
- * preflight — wraps around `withSupabase` instead of sitting in the array.
+ * timing). The auth-failure context carries `userClaims`/`jwtClaims` as
+ * `null` and omits `authMode`, `authKeyName`, and the Supabase clients — no
+ * caller was verified, so none of those exist. A replacement response of a
+ * different status is discarded, and an entry that throws on this path is
+ * logged and the response returned undecorated. A middleware that must
+ * *answer* unauthenticated requests — OAuth discovery, custom preflight —
+ * wraps around `withSupabase` instead of sitting in the array.
  *
  * > **Alpha.** The `middleware` option is in alpha, alongside
  * > `@supabase/middleware` 0.x. Its shape may change between 0.x releases.
@@ -232,7 +234,11 @@ export function withSupabase<Database = unknown>(
       try {
         const result = await folded(req, ctx)
         return result.status === original.status ? result : original
-      } catch {
+      } catch (err) {
+        console.error(
+          'withSupabase: a middleware entry threw while the error response passed through the response phase; the response is returned undecorated. Entries on this path see null claims and no Supabase clients.',
+          err,
+        )
         return original
       }
     }

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -118,10 +118,13 @@ export function withSupabase<
  * the success path (the chain folds once). The auth-failure context carries
  * `userClaims`/`jwtClaims` as `null` and omits `authMode`, `authKeyName`,
  * and the Supabase clients — no caller was verified, so none of those
- * exist. A replacement response of a different status is discarded; a
- * same-status replacement keeps the error CORS headers where the entry set
- * none of its own; and an entry that throws on this path is logged and the
- * response returned undecorated. A middleware that must *answer*
+ * exist. A client-construction failure keeps the verified claims and
+ * `authMode`/`authKeyName`; only the clients are absent. A replacement
+ * response of a different status is discarded; a same-status replacement
+ * keeps the error response's headers (CORS, the error-code header) where
+ * the entry set no value of its own; a drained body is rebuilt; and an
+ * entry that throws on this path is logged and the response returned
+ * undecorated. A middleware that must *answer*
  * unauthenticated requests — OAuth discovery, custom preflight — wraps
  * around `withSupabase` instead of sitting in the array.
  *
@@ -241,34 +244,53 @@ export function withSupabase<Database = unknown>(
     // clients. The composed result is kept only when it has the same status
     // as the original: the array may shape an error response, never
     // commandeer it. An entry that throws here falls back to the original.
+    // `makeOriginal` rebuilds the error response on demand: an entry may
+    // legitimately drain the response body (logging), and a drained body
+    // cannot be re-sent — every fallback and reconstruction path needs a
+    // fresh copy, never the instance the entries touched.
     const respondThroughMiddleware = async (
-      original: Response,
+      makeOriginal: () => Response,
       ctx: object,
     ): Promise<Response> => {
-      if ((config.middleware ?? []).length === 0) return original
+      if ((config.middleware ?? []).length === 0) return makeOriginal()
+      const original = makeOriginal()
       try {
         const result = await userComposed(req, {
           ...ctx,
           [withSupabaseCtxMarker]: true,
           [originalResponseKey]: original,
         })
-        if (result.status !== original.status) return original
-        if (result === original) return result
-        // A same-status replacement is a fresh Response, so the error CORS
-        // headers (and the exposed error-code header) are re-applied where
-        // the entry did not set its own values — a decorated 401 must stay
-        // readable cross-origin.
-        const restored = new Response(result.body, result)
-        for (const [key, value] of Object.entries(errorHeaders())) {
-          if (!restored.headers.has(key)) restored.headers.set(key, value)
+        if (result.status !== original.status) return makeOriginal()
+        if (result === original) {
+          if (!result.bodyUsed) return result
+          // An entry read the body and returned the same instance: the
+          // decorated headers are kept, the body comes from a fresh copy.
+          return new Response(makeOriginal().body, {
+            status: result.status,
+            statusText: result.statusText,
+            headers: result.headers,
+          })
         }
+        // A drained same-status replacement cannot be sent at all.
+        if (result.bodyUsed) return makeOriginal()
+        // A same-status replacement is a fresh Response, so the error
+        // response's headers (CORS, the exposed error-code header) are
+        // re-applied where the entry set no value of its own — a shaped 401
+        // must stay readable cross-origin and keep its machine-readable
+        // code. Body-derived headers stay the replacement's own.
+        const restored = new Response(result.body, result)
+        makeOriginal().headers.forEach((value, key) => {
+          const name = key.toLowerCase()
+          if (name === 'content-type' || name === 'content-length') return
+          if (!restored.headers.has(key)) restored.headers.set(key, value)
+        })
         return restored
       } catch (err) {
         console.error(
           'withSupabase: a middleware entry threw while the error response passed through the response phase; the response is returned undecorated. Entries on this path see null claims and no Supabase clients.',
           err,
         )
-        return original
+        return makeOriginal()
       }
     }
 
@@ -294,10 +316,11 @@ export function withSupabase<Database = unknown>(
     })
     if (error) {
       return respondThroughMiddleware(
-        errorResponse(error, {
-          headers: errorHeaders(),
-          errors: config.errors,
-        }),
+        () =>
+          errorResponse(error, {
+            headers: errorHeaders(),
+            errors: config.errors,
+          }),
         { ...baseContext, userClaims: null, jwtClaims: null },
       )
     }
@@ -354,10 +377,11 @@ export function withSupabase<Database = unknown>(
             : null
       if (!mapped) throw e
       return respondThroughMiddleware(
-        errorResponse(mapped, {
-          headers: errorHeaders(),
-          errors: config.errors,
-        }),
+        () =>
+          errorResponse(mapped, {
+            headers: errorHeaders(),
+            errors: config.errors,
+          }),
         {
           ...baseContext,
           userClaims: auth.userClaims,


### PR DESCRIPTION
Middleware entries in `withSupabase`'s `middleware` array never observed the responses `withSupabase` builds itself. This PR routes those responses through the array's response phase, with guards.

## Scope

| Behavior with a response-seam middleware in the array | Status |
|---|---|
| `WWW-Authenticate` (and any decoration) on auth-generated `401`s | ✅ Fixed |
| Decoration of client-construction error responses | ✅ Fixed |
| Silent failure on misplaced pre-auth middleware | ✅ Fixed (runtime warning) |
| Serving OAuth discovery from inside the array | ❌ Out of scope (needs pre-auth placement) |
| Middleware's own `OPTIONS`/preflight handling from inside the array | ❌ Out of scope (needs pre-auth placement) |

The wrap form — `withOAuthProtectedResource(cfg, withSupabase(cfg, handler))` or `pipeline([withOAuthProtectedResource(cfg)], withSupabase(cfg, handler))` — remains the supported placement for the full OAuth flow. A placement support table is added to `docs/api-reference.md`.

## Problem

Auth failures and client-construction failures returned directly, so an entry like `withOAuthProtectedResource` could not attach `WWW-Authenticate` to a 401. MCP clients got a bare 401 with no pointer to the authorization server, and nothing failed loudly.

## Fix

The middleware chain folds once at wrap time around a dual-purpose terminal: normally it calls the user handler; when the context carries a `withSupabase`-built error response under a private symbol key, it returns that response so entries run their response phase against it. Folding once means entry state (rate-limit counters, caches) is shared between the success and error paths, so a rate limiter genuinely throttles repeated bad-auth traffic.

Guards bound the semantics:

- **Same-status rule:** an entry can decorate an error response but cannot swap it for a different-status one, so a request-phase short-circuit cannot bypass the auth gate.
- **Header restoration:** a same-status replacement gets the original error response's headers (CORS, the exposed error-code header) re-applied where the entry set no value of its own; body-derived headers stay the replacement's.
- **Body restoration:** an entry that drains the body (logging) gets it rebuilt from a fresh copy; header decorations survive.
- **Crash fallback:** an entry that throws on this path is logged via `console.error` and the plain error response is returned.

On auth failure the context carries `userClaims: null` and `jwtClaims: null`, with no auth mode or clients; on client-construction failure the verified claims and auth mode are present and only the clients are absent. The OPTIONS/CORS short-circuit is unchanged, and nothing changes when `middleware` is absent or empty.

`withOAuthProtectedResource` warns once per process when it detects (via a private context marker, not key names) that it sits inside a `withSupabase` array.

## Tests

Fourteen new unit tests cover the routing on both error paths, the same-status and crash guards, entry-state persistence across error-path requests, header and body restoration, the context shape on each path, the in-array 401 enrichment, discovery staying wrap-form, and the placement warning (including no false positive from an unrelated `userClaims` key).

## Validation

Tested end-to-end against a real MCP Edge Function in supabase-community/edge-function-mcp-sandbox#11: 401 enrichment works, authenticated MCP calls unaffected, discovery/preflight behave as documented, warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
