### PR TITLE
docs: mark middleware and oauth surfaces alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ withSupabase(
 
 `env` overrides environment variable resolution. Defaults to reading `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEYS`, `SUPABASE_SECRET_KEYS`, and `SUPABASE_JWKS` from the runtime environment.
 
+`middleware` composes additional entries onto the context — they run after the Supabase context is established and contribute their own typed keys. The first-party entries live on the `@supabase/server/middleware/*` subpaths; see [Postgres](#postgres-rls-scoped-queries).
+
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
+
 ## Framework Adapters
 
 Adapters wrap `withSupabase` for a specific framework's middleware contract. They ship inside `@supabase/server`, so a single `npm install @supabase/server` covers the framework you're using — no separate package per adapter.
@@ -440,6 +447,11 @@ export default {
 
 ## Postgres (RLS-scoped queries)
 
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
+
 When PostgREST isn't the right tool — joins, CTEs, window functions — `withPostgresClient` puts a direct Postgres connection on `ctx.postgres`, scoped to the caller by RLS:
 
 ```ts
@@ -529,13 +541,13 @@ No. `@supabase/ssr` handles cookie-based session management for frameworks like 
 | `@supabase/server/adapters/h3`                | `withSupabase` (H3 / Nuxt middleware)                                                                             |
 | `@supabase/server/adapters/elysia`            | `withSupabase` (Elysia plugin)                                                                                    |
 | `@supabase/server/adapters/nestjs`            | `withSupabase` (NestJS guard), `SupabaseCtx` (param decorator)                                                    |
-| `@supabase/server/middleware/client`          | `withSupabaseClient` (RLS-scoped `ctx.supabase` client)                                                           |
-| `@supabase/server/middleware/admin-client`    | `withSupabaseAdminClient` (`ctx.supabaseAdmin`, bypasses RLS)                                                     |
-| `@supabase/server/middleware/claims`          | `withClaims` (JWKS-verified `ctx.jwtClaims`)                                                                      |
-| `@supabase/server/middleware/required-claims` | `withRequiredClaims` (user-mode auth gate, non-null `ctx.jwtClaims`)                                              |
-| `@supabase/server/middleware/postgres`        | `withPostgresClient` (RLS-scoped `ctx.postgres` client)                                                           |
-| `@supabase/server/middleware/postgres-admin`  | `withPostgresAdminClient` (`ctx.postgresAdmin`, bypasses RLS)                                                     |
-| `@supabase/server/oauth-protected-resource`   | `withOAuthProtectedResource`, `fromSupabaseUrl`, `resourceMetadataResponse`, `unauthorizedResponse`               |
+| `@supabase/server/middleware/client`          | **Alpha.** `withSupabaseClient` (RLS-scoped `ctx.supabase` client)                                                |
+| `@supabase/server/middleware/admin-client`    | **Alpha.** `withSupabaseAdminClient` (`ctx.supabaseAdmin`, bypasses RLS)                                          |
+| `@supabase/server/middleware/claims`          | **Alpha.** `withClaims` (JWKS-verified `ctx.jwtClaims`)                                                           |
+| `@supabase/server/middleware/required-claims` | **Alpha.** `withRequiredClaims` (user-mode auth gate, non-null `ctx.jwtClaims`)                                   |
+| `@supabase/server/middleware/postgres`        | **Alpha.** `withPostgresClient` (RLS-scoped `ctx.postgres` client)                                                |
+| `@supabase/server/middleware/postgres-admin`  | **Alpha.** `withPostgresAdminClient` (`ctx.postgresAdmin`, bypasses RLS)                                          |
+| `@supabase/server/oauth-protected-resource`   | **Alpha.** `withOAuthProtectedResource`, `fromSupabaseUrl`, `resourceMetadataResponse`, `unauthorizedResponse`    |
 | `@supabase/server/peer/supabase-js`           | Re-exported `supabase-js` types (`SupabaseClient`, `PostgrestError`, …)                                           |
 
 ## Documentation

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,6 +22,27 @@ Wraps a fetch handler with auth, CORS, and client creation. Returns a `(req: Req
 - Returns JSON error response on auth failure
 - Adds CORS headers to all responses
 
+A `middleware` array selects a second overload, which accumulates each entry's
+contribution onto the handler's `ctx`:
+
+```ts
+function withSupabase<
+  Database = unknown,
+  const Entries extends readonly Entry[] = readonly Entry[],
+>(
+  config: WithSupabaseConfig & { middleware: Entries },
+  handler: (
+    req: Request,
+    ctx: SupabaseContext<Database> & MiddlewareCtx<Entries>,
+  ) => Promise<Response>,
+): (req: Request) => Promise<Response>
+```
+
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
+
 ### createSupabaseContext
 
 ```ts
@@ -168,6 +189,11 @@ Defaults to `auth: 'user'` when config is omitted.
 
 ## @supabase/server/middleware/claims
 
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
+
 ### withClaims
 
 ```ts
@@ -205,6 +231,11 @@ Defaults to `SUPABASE_JWKS` (inline JSON) or `SUPABASE_JWKS_URL` (https endpoint
 ---
 
 ## @supabase/server/middleware/required-claims
+
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
 
 ### withRequiredClaims
 
@@ -264,6 +295,11 @@ Defaults to `SUPABASE_JWKS` (inline JSON) or `SUPABASE_JWKS_URL` (https endpoint
 ---
 
 ## @supabase/server/middleware/postgres
+
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
 
 ### withPostgresClient
 
@@ -360,6 +396,11 @@ The minimal claims shape `withPostgresClient` requires upstream at `ctx.jwtClaim
 ---
 
 ## @supabase/server/middleware/postgres-admin
+
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
 
 ### withPostgresAdminClient
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -38,7 +38,7 @@ Access-Control-Expose-Headers: x-supabase-server-error
 
 The code is repeated in the `x-supabase-server-error` response header, and added to `Access-Control-Expose-Headers` so cross-origin browser code can actually read it.
 
-Every layer that answers a request directly uses this shape: `withSupabase`, and the middleware that short-circuit (`withClaims`, `withRequiredClaims`, `withPostgresClient`).
+Every layer that answers a request directly uses this shape: `withSupabase`, and the middleware that short-circuit (`withClaims`, `withRequiredClaims`, `withPostgresClient`). The `@supabase/server/middleware/*` subpaths and `@supabase/server/oauth-protected-resource` are alpha; the error payload documented here is stable either way.
 
 ## Trimming the response body
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,5 +1,10 @@
 # Postgres (`ctx.postgres`)
 
+> **Alpha.** The `middleware` option and the `@supabase/server/middleware/*`
+> subpaths track `@supabase/middleware` 0.x — entry shapes, context keys, and
+> config options may change between 0.x releases. Everything else in
+> `@supabase/server` is stable.
+
 Two middleware give you a direct Postgres connection, mirroring the `ctx.supabase` / `ctx.supabaseAdmin` pair:
 
 | Middleware                | Subpath                       | Contributes         | RLS                            |

--- a/src/middleware/admin-client/index.ts
+++ b/src/middleware/admin-client/index.ts
@@ -9,10 +9,14 @@ import { CreateSupabaseClientError, EnvError, Errors } from '../../errors.js'
 import type { CreateAdminClientOptions } from '../../types.js'
 
 /**
- * Configuration for {@link withSupabaseAdminClient} — the same environment and
- * client options `createAdminClient` accepts, minus the per-request auth
- * identity (which is read from the upstream context).
+ * **Alpha.** Configuration for {@link withSupabaseAdminClient} — the same
+ * environment and client options `createAdminClient` accepts, minus the
+ * per-request auth identity (which is read from the upstream context).
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export type WithSupabaseAdminClientConfig = Omit<
@@ -55,9 +59,9 @@ const base = defineMiddleware<
 })
 
 /**
- * Contributes `ctx.supabaseAdmin` — an admin Supabase client that bypasses
- * Row-Level Security, authenticated with a secret key. This is the same
- * middleware `withSupabase` composes internally to build its context.
+ * **Alpha.** Contributes `ctx.supabaseAdmin` — an admin Supabase client that
+ * bypasses Row-Level Security, authenticated with a secret key. This is the
+ * same middleware `withSupabase` composes internally to build its context.
  *
  * The client is constructed on the first property access of
  * `ctx.supabaseAdmin` and memoized for the request. A handler that never
@@ -80,6 +84,10 @@ const base = defineMiddleware<
  * }
  * ```
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export function withSupabaseAdminClient<Database = unknown>(

--- a/src/middleware/claims/index.ts
+++ b/src/middleware/claims/index.ts
@@ -15,8 +15,12 @@ import {
 import type { JWTClaims } from '../../types.js'
 
 /**
- * Configuration for {@link withClaims}.
+ * **Alpha.** Configuration for {@link withClaims}.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export interface WithClaimsConfig {
@@ -29,9 +33,9 @@ export interface WithClaimsConfig {
 }
 
 /**
- * Contributes `ctx.jwtClaims` by verifying the caller's Bearer token against
- * the project JWKS — the same verification core `withSupabase` uses for its
- * `user` auth mode.
+ * **Alpha.** Contributes `ctx.jwtClaims` by verifying the caller's Bearer
+ * token against the project JWKS — the same verification core `withSupabase`
+ * uses for its `user` auth mode.
  *
  * Use this when composing a standalone `pipeline([...], handler)` that is
  * **not** wrapped by `withSupabase` — for example a Supabase-agnostic Edge
@@ -70,6 +74,10 @@ export interface WithClaimsConfig {
  * }
  * ```
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export const withClaims: Middleware<

--- a/src/middleware/client/index.ts
+++ b/src/middleware/client/index.ts
@@ -9,10 +9,15 @@ import { CreateSupabaseClientError, EnvError, Errors } from '../../errors.js'
 import type { CreateContextClientOptions } from '../../types.js'
 
 /**
- * Configuration for {@link withSupabaseClient} — the same environment and
- * client options `createContextClient` accepts, minus the per-request auth
- * identity (which is read from the request and the upstream context).
+ * **Alpha.** Configuration for {@link withSupabaseClient} — the same
+ * environment and client options `createContextClient` accepts, minus the
+ * per-request auth identity (which is read from the request and the upstream
+ * context).
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export type WithSupabaseClientConfig = Omit<CreateContextClientOptions, 'auth'>
@@ -58,12 +63,12 @@ const base = defineMiddleware<
 })
 
 /**
- * Contributes `ctx.supabase` — a Supabase client scoped to the caller's
- * identity, so Row-Level Security policies apply. This is the same middleware
- * `withSupabase` composes internally to build its context.
+ * **Alpha.** Contributes `ctx.supabase` — a Supabase client scoped to the
+ * caller's identity, so Row-Level Security policies apply. This is the same
+ * middleware `withSupabase` composes internally to build its context.
  *
  * Standalone, the caller's Bearer token (when present) is attached unverified —
- * PostgREST verifies it on every query. Compose {@link claims.withClaims}
+ * PostgREST verifies it on every query. Compose {@link middleware/claims!withClaims}
  * upstream when the pipeline itself needs verified claims.
  *
  * @throws {@link index.EnvError} When `SUPABASE_URL` or the publishable key is
@@ -83,6 +88,10 @@ const base = defineMiddleware<
  * }
  * ```
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export function withSupabaseClient<Database = unknown>(

--- a/src/middleware/postgres-admin/index.ts
+++ b/src/middleware/postgres-admin/index.ts
@@ -15,8 +15,12 @@ export type { PostgresApi }
 export { ident }
 
 /**
- * Configuration for {@link withPostgresAdminClient}.
+ * **Alpha.** Configuration for {@link withPostgresAdminClient}.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export interface WithPostgresAdminClientConfig {
@@ -25,8 +29,8 @@ export interface WithPostgresAdminClientConfig {
 }
 
 /**
- * Contributes `ctx.postgresAdmin` — a `pg` client that **bypasses RLS**, for
- * full-table access. The direct-connection counterpart to
+ * **Alpha.** Contributes `ctx.postgresAdmin` — a `pg` client that **bypasses
+ * RLS**, for full-table access. The direct-connection counterpart to
  * `withSupabaseAdminClient`, and the deliberate opt-out from the guardrails
  * `withPostgresClient` (`@supabase/server/middleware/postgres`) enforces.
  *
@@ -68,6 +72,10 @@ export interface WithPostgresAdminClientConfig {
  * > **Runtime note.** `pg` needs raw TCP, so this runs on Node/Deno (including
  * > the Supabase Edge runtime), **not** on Workers-style isolates.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export const withPostgresAdminClient: Middleware<

--- a/src/middleware/postgres/index.ts
+++ b/src/middleware/postgres/index.ts
@@ -56,12 +56,17 @@ function resolveRole(claims: RequestClaims | null): string | Response {
 }
 
 /**
- * Minimal claims shape {@link withPostgresClient} needs on the upstream context.
+ * **Alpha.** Minimal claims shape {@link withPostgresClient} needs on the
+ * upstream context.
  *
  * Satisfied both by `withSupabase`'s JWKS-verified `ctx.jwtClaims` and by the
  * standalone `withClaims` middleware — `withPostgresClient` only reads `role`
  * and serializes the whole object into `request.jwt.claims`.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export interface RequestClaims {
@@ -70,8 +75,12 @@ export interface RequestClaims {
 }
 
 /**
- * Configuration for {@link withPostgresClient}.
+ * **Alpha.** Configuration for {@link withPostgresClient}.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export interface WithPostgresClientConfig {
@@ -80,10 +89,11 @@ export interface WithPostgresClientConfig {
 }
 
 /**
- * Contributes `ctx.postgres` — an RLS-scoped `pg` client, the safe version of
- * "authenticate, then query as the user". This is the direct-connection
- * counterpart to `withSupabaseClient`, and its service-role companion is
- * `withPostgresAdminClient` (`@supabase/server/middleware/postgres-admin`).
+ * **Alpha.** Contributes `ctx.postgres` — an RLS-scoped `pg` client, the safe
+ * version of "authenticate, then query as the user". This is the
+ * direct-connection counterpart to `withSupabaseClient`, and its service-role
+ * companion is `withPostgresAdminClient`
+ * (`@supabase/server/middleware/postgres-admin`).
  *
  * Every query runs in its own short transaction that injects the caller's
  * claims and drops to their role, exactly like PostgREST:
@@ -127,6 +137,10 @@ export interface WithPostgresClientConfig {
  * > **Runtime note.** `pg` needs raw TCP, so this runs on Node/Deno (including
  * > the Supabase Edge runtime), **not** on Workers-style isolates.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export const withPostgresClient: Middleware<

--- a/src/middleware/required-claims/index.ts
+++ b/src/middleware/required-claims/index.ts
@@ -22,8 +22,12 @@ import {
 import type { JWTClaims } from '../../types.js'
 
 /**
- * Configuration for {@link withRequiredClaims}.
+ * **Alpha.** Configuration for {@link withRequiredClaims}.
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export interface WithRequiredClaimsConfig {
@@ -36,9 +40,9 @@ export interface WithRequiredClaimsConfig {
 }
 
 /**
- * The user-mode auth gate: requires a valid user JWT and contributes
- * **non-null** `ctx.jwtClaims`. Verification runs against the project JWKS,
- * the same core `withSupabase` uses for its `user` auth mode.
+ * **Alpha.** The user-mode auth gate: requires a valid user JWT and
+ * contributes **non-null** `ctx.jwtClaims`. Verification runs against the
+ * project JWKS, the same core `withSupabase` uses for its `user` auth mode.
  *
  * This is the required-caller counterpart to `withClaims`, which contributes
  * claims when a token is present and lets token-less requests proceed as
@@ -86,6 +90,10 @@ export interface WithRequiredClaimsConfig {
  * }
  * ```
  *
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ *
+ * @alpha
  * @category Middleware
  */
 export const withRequiredClaims: Middleware<

--- a/src/oauth-protected-resource/index.ts
+++ b/src/oauth-protected-resource/index.ts
@@ -1,5 +1,12 @@
 /**
- * OAuth 2.1 Protected Resource middleware (RFC 9728) for Supabase Edge Functions.
+ * **Alpha.** OAuth 2.1 Protected Resource middleware (RFC 9728) for Supabase
+ * Edge Functions.
+ *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @module
  * @packageDocumentation
  */

--- a/src/oauth-protected-resource/responses.ts
+++ b/src/oauth-protected-resource/responses.ts
@@ -10,10 +10,16 @@ import type {
 } from './types.js'
 
 /**
- * `401` response with a `WWW-Authenticate: Bearer resource_metadata="..."` header (RFC 9728).
+ * **Alpha.** `401` response with a
+ * `WWW-Authenticate: Bearer resource_metadata="..."` header (RFC 9728).
  * The metadata URL defaults to the Edge Functions derivation and throws off
  * platform; pass `resourceMetadataUrl` to override for custom setups.
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Middleware
  */
 export function unauthorizedResponse(
@@ -33,11 +39,17 @@ export function unauthorizedResponse(
 }
 
 /**
- * RFC 9728 OAuth Protected Resource Metadata response.
+ * **Alpha.** RFC 9728 OAuth Protected Resource Metadata response.
  * Advertises the authorization server, resource URI, and bearer methods supported.
  * URLs default to the Edge Functions derivation and throw off platform; pass
  * `resource` / `authorizationServers` to override.
  *
+ *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Middleware
  */
 export function resourceMetadataResponse(

--- a/src/oauth-protected-resource/types.ts
+++ b/src/oauth-protected-resource/types.ts
@@ -1,6 +1,11 @@
 /**
- * Options for {@link unauthorizedResponse}.
+ * **Alpha.** Options for {@link unauthorizedResponse}.
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Types
  */
 export interface UnauthorizedResponseOptions {
@@ -9,8 +14,13 @@ export interface UnauthorizedResponseOptions {
 }
 
 /**
- * Options for {@link resourceMetadataResponse}.
+ * **Alpha.** Options for {@link resourceMetadataResponse}.
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Types
  */
 export interface ResourceMetadataOptions {

--- a/src/oauth-protected-resource/url.ts
+++ b/src/oauth-protected-resource/url.ts
@@ -9,8 +9,13 @@ import { AUTH_PATH_PREFIX, EDGE_FUNCTIONS_PATH_PREFIX } from './paths.js'
 import { isEdgeFunctions } from './runtime.js'
 
 /**
- * A configured URL: either a fixed value, or derived per request.
+ * **Alpha.** A configured URL: either a fixed value, or derived per request.
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Types
  */
 export type UrlOption = string | ((req: Request) => string)
@@ -154,7 +159,8 @@ export function defaultAuthorizationServer(req: Request): string {
 }
 
 /**
- * Points `authorizationServer` at a Supabase project's Auth issuer.
+ * **Alpha.** Points `authorizationServer` at a Supabase project's Auth
+ * issuer.
  *
  * Use this off Supabase Edge Functions, where the app's own origin is unrelated
  * to the Supabase project's, so the issuer cannot be derived from the request.
@@ -162,6 +168,11 @@ export function defaultAuthorizationServer(req: Request): string {
  * @param supabaseUrl - The project URL, e.g. `https://<ref>.supabase.co` (the
  * same value passed to `createClient()`).
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Middleware
  *
  * @example

--- a/src/oauth-protected-resource/with-oauth-protected-resource.ts
+++ b/src/oauth-protected-resource/with-oauth-protected-resource.ts
@@ -5,19 +5,32 @@ import { resourceMetadataResponse } from './responses.js'
 import { getAuthUrl, getResourceMetadataUrl, getResourceUrl } from './url.js'
 import type { UrlOption } from './url.js'
 
-/** Shape contributed at `ctx.oauthProtectedResource`. */
+/**
+ * **Alpha.** Shape contributed at `ctx.oauthProtectedResource`.
+ *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
+ */
 export interface OAuthProtectedResourceContribution {
   /** Absolute URL of this resource's OAuth Protected Resource Metadata document (RFC 9728). */
   resourceMetadataUrl: string
 }
 
 /**
- * Configuration for {@link withOAuthProtectedResource}.
+ * **Alpha.** Configuration for {@link withOAuthProtectedResource}.
  *
  * Both options accept a fixed string or a function of the request. Both default
  * to values derived from the request as it arrives through the Supabase Edge
  * Functions proxy, so no configuration is needed there.
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Types
  */
 export interface OAuthProtectedResourceConfig {
@@ -43,7 +56,8 @@ export interface OAuthProtectedResourceConfig {
 }
 
 /**
- * Wraps a request handler with OAuth 2.1 Protected Resource behavior (RFC 9728).
+ * **Alpha.** Wraps a request handler with OAuth 2.1 Protected Resource
+ * behavior (RFC 9728).
  *
  * - Serves OAuth Protected Resource Metadata at `GET {resource}/oauth-protected-resource`
  *   (with permissive CORS, including the `OPTIONS` preflight, so browser-based clients can read it)
@@ -66,6 +80,11 @@ export interface OAuthProtectedResourceConfig {
  * handler's `ctx` when the outermost call is anchored with
  * `satisfies FetchHandler` — see `withSupabase`'s type note.
  *
+ * The OAuth Protected Resource surface is alpha — the config shape, the
+ * contributed context key, and the metadata route may change in a minor
+ * release.
+ *
+ * @alpha
  * @category Middleware
  *
  * @example Supabase Edge Functions — zero config

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -83,7 +83,13 @@ export function withSupabase<
   Database = unknown,
   Base extends BaseContext = BaseContext,
 >(
-  config: WithSupabaseConfig & { middleware?: never },
+  config: WithSupabaseConfig & {
+    /**
+     * Absent in this overload. Supplying a `middleware` array selects the
+     * composable-middleware variant, which is alpha.
+     */
+    middleware?: never
+  },
   // `NoInfer<Base>` blocks inference from the handler argument, leaving the
   // contextual return type as the single source of `Base` — the same split the
   // engine's `Middleware` interface documents. Without it, an annotated handler
@@ -99,15 +105,17 @@ export function withSupabase<
 ): (req: Request, ctx?: Base) => Promise<Response>
 
 /**
- * Variant that accepts a `middleware` array — each `withFoo(config)` call
- * returns an `Entry` from `@supabase/middleware`. Middleware run **after**
- * the Supabase context is established; they receive `ctx.supabase`,
- * `ctx.userClaims`, etc. already present and contribute their own typed keys
- * on top. (This is the server leg of a Plugin: the package's middleware goes
- * here; its client namespace goes in `createClient`'s `plugins` array.)
+ * **Alpha.** Variant that accepts a `middleware` array — each
+ * `withFoo(config)` call returns an `Entry` from `@supabase/middleware`.
+ * Middleware run **after** the Supabase context is established; they receive
+ * `ctx.supabase`, `ctx.userClaims`, etc. already present and contribute their
+ * own typed keys on top. (This is the server leg of a Plugin: the package's
+ * middleware goes here; its client namespace goes in `createClient`'s
+ * `plugins` array.)
  *
- * > **Alpha.** The `middleware` option is in alpha, alongside
- * > `@supabase/middleware` 0.x. Its shape may change between 0.x releases.
+ * The composable middleware surface tracks `@supabase/middleware` 0.x — entry
+ * shapes, context keys, and config options may change between 0.x releases.
+ * The no-`middleware` overload above is stable.
  *
  * @example
  * ```ts
@@ -137,13 +145,28 @@ export function withSupabase<
  * fails to compile. The failure sentinel occupies the handler parameter, never
  * `entries`, so `const Entries` tuple inference stays intact, as in the
  * engine's `pipeline`.
+ *
+ * @alpha
  */
 export function withSupabase<
   Database = unknown,
   const Entries extends readonly AnyEntry[] = readonly AnyEntry[],
   Base extends BaseContext = BaseContext,
 >(
-  config: WithSupabaseConfig & { middleware: Entries },
+  config: WithSupabaseConfig & {
+    /**
+     * **Alpha.** Entries to run after the Supabase context is established.
+     * Each receives `ctx.supabase`, `ctx.jwtClaims`, and the rest already
+     * present, and contributes its own typed keys on top.
+     *
+     * The composable middleware surface tracks `@supabase/middleware` 0.x —
+     * entry shapes, context keys, and config options may change between 0.x
+     * releases.
+     *
+     * @alpha
+     */
+    middleware: Entries
+  },
   // Validation sits on the handler parameter (never on `entries`) so it does
   // not disrupt `const Entries` tuple inference; the seed is the context the
   // entries actually see at runtime.

--- a/typedoc.json
+++ b/typedoc.json
@@ -6,8 +6,12 @@
     "src/adapters/hono/index.ts",
     "src/adapters/h3/index.ts",
     "src/adapters/elysia/index.ts",
+    "src/middleware/client/index.ts",
+    "src/middleware/admin-client/index.ts",
     "src/middleware/postgres/index.ts",
-    "src/middleware/postgres-admin/index.ts"
+    "src/middleware/postgres-admin/index.ts",
+    "src/middleware/claims/index.ts",
+    "src/middleware/required-claims/index.ts"
   ],
   "out": "api-docs",
   "json": "api-docs/spec.json",


### PR DESCRIPTION
Mark `middleware` related things as `alpha`.