### PR TITLE
fix: recognize Supabase edge runtime via SB_EXECUTION_ID

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,16 +2,17 @@
 
 On Supabase Platform and Local Development (CLI), all variables are auto-provisioned — no configuration needed
 
-| Variable                    | Format                             | Description                                                                                                     | Available in                      |
-| --------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `SUPABASE_URL`              | `https://<ref>.supabase.co`        | Your Supabase project URL                                                                                       | All                               |
-| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_..."}` | Named publishable keys as JSON object                                                                           | All                               |
-| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_..."}`      | Named secret keys as JSON object                                                                                | All                               |
-| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`        | Inline JSON Web Key Set for JWT verification                                                                    | All                               |
-| `SUPABASE_PUBLISHABLE_KEY`  | `sb_publishable_...`               | Single publishable key (fallback)                                                                               | Self-hosted, if manually exported |
-| `SUPABASE_SECRET_KEY`       | `sb_secret_...`                    | Single secret key (fallback)                                                                                    | Self-hosted, if manually exported |
-| `SUPABASE_PUBLIC_URL`       | `https://<ref>.supabase.co`        | Externally-visible URL of the Supabase stack. Preferred origin for OAuth protected resource metadata            | Self-hosted                       |
-| `SUPABASE_FUNCTION_SLUG`    | `my-function`                      | The running function's slug. Yields a canonical `/functions/v1/{slug}` resource identifier with no path parsing | Edge Functions                    |
+| Variable                    | Format                             | Description                                                                                                                                              | Available in                      |
+| --------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `SUPABASE_URL`              | `https://<ref>.supabase.co`        | Your Supabase project URL                                                                                                                                | All                               |
+| `SUPABASE_PUBLISHABLE_KEYS` | `{"default":"sb_publishable_..."}` | Named publishable keys as JSON object                                                                                                                    | All                               |
+| `SUPABASE_SECRET_KEYS`      | `{"default":"sb_secret_..."}`      | Named secret keys as JSON object                                                                                                                         | All                               |
+| `SUPABASE_JWKS`             | `{"keys":[...]}` or `[...]`        | Inline JSON Web Key Set for JWT verification                                                                                                             | All                               |
+| `SUPABASE_PUBLISHABLE_KEY`  | `sb_publishable_...`               | Single publishable key (fallback)                                                                                                                        | Self-hosted, if manually exported |
+| `SUPABASE_SECRET_KEY`       | `sb_secret_...`                    | Single secret key (fallback)                                                                                                                             | Self-hosted, if manually exported |
+| `SUPABASE_PUBLIC_URL`       | `https://<ref>.supabase.co`        | Externally-visible URL of the Supabase stack. Preferred origin for OAuth protected resource metadata                                                     | Self-hosted                       |
+| `SUPABASE_FUNCTION_SLUG`    | `my-function`                      | The running function's slug. Yields a canonical `/functions/v1/{slug}` resource identifier with no path parsing                                          | Edge Functions                    |
+| `SB_EXECUTION_ID`           | UUID                               | Set by the Edge Functions runtime for every invocation. Marks the Edge Functions environment for `withOAuthProtectedResource`'s request-derived defaults | Edge Functions                    |
 
 ## Non-Supabase environments (Node.js, Bun, Cloudflare, self-hosted)
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -245,7 +245,7 @@ Set `SUPABASE_SECRET_KEY`, or add a `"default"` entry to `SUPABASE_SECRET_KEYS`,
 
 ### `MISSING_RESOURCE_SERVER`
 
-`withOAuthProtectedResource` is running outside Supabase Edge Functions, where it can't derive the resource URL from the request. Pass `resourceServer` — `hint` shows the shape.
+`withOAuthProtectedResource` is running outside Supabase Edge Functions, where it can't derive the resource URL from the request. Pass `resourceServer` — `hint` shows the shape. `withOAuthProtectedResource` treats the environment as Edge Functions when `SUPABASE_FUNCTION_SLUG` or `SB_EXECUTION_ID` is set, or when the host runtime is Deno.
 
 ### `MISSING_AUTHORIZATION_SERVER`
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -245,7 +245,7 @@ Set `SUPABASE_SECRET_KEY`, or add a `"default"` entry to `SUPABASE_SECRET_KEYS`,
 
 ### `MISSING_RESOURCE_SERVER`
 
-`withOAuthProtectedResource` is running outside Supabase Edge Functions, where it can't derive the resource URL from the request. Pass `resourceServer` — `hint` shows the shape. `withOAuthProtectedResource` treats the environment as Edge Functions when `SUPABASE_FUNCTION_SLUG` or `SB_EXECUTION_ID` is set, or when the host runtime is Deno.
+`withOAuthProtectedResource` is running outside Supabase Edge Functions, where it can't derive the resource URL from the request. Pass `resourceServer` — `hint` shows the shape. `withOAuthProtectedResource` treats the environment as Edge Functions when `SUPABASE_FUNCTION_SLUG` or `SB_EXECUTION_ID` is set, or when the host runtime is Deno. `details.runtime` carries the runtime name the SDK detected.
 
 ### `MISSING_AUTHORIZATION_SERVER`
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -363,7 +363,7 @@ const EnvErrorMap = {
       },
     ),
 
-  [MissingResourceServerError]: (): EnvError =>
+  [MissingResourceServerError]: (runtime: string): EnvError =>
     new EnvError(
       'resourceServer is required outside Supabase Edge Functions and could not be derived.',
       MissingResourceServerError,
@@ -371,7 +371,9 @@ const EnvErrorMap = {
         hint:
           'Pass it to withOAuthProtectedResource(), e.g. ' +
           "{ resourceServer: (req) => new URL(req.url).origin + '/api/mcp' }. On Edge Functions it " +
-          'is derived from the request instead.',
+          'is derived from the request instead; that environment is recognized by ' +
+          'SUPABASE_FUNCTION_SLUG or SB_EXECUTION_ID being set, or by a Deno host runtime.',
+        details: { runtime },
       },
     ),
 

--- a/src/oauth-protected-resource/runtime.test.ts
+++ b/src/oauth-protected-resource/runtime.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isEdgeFunctions } from './runtime.js'
+
+// `runtimeName` is a module-level constant in `@supabase/middleware` (std-env's
+// `runtime`), so it is swapped per test through a getter; `getEnv` stays real.
+const runtime = vi.hoisted(() => ({ name: 'node' }))
+vi.mock('@supabase/middleware', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@supabase/middleware')>()
+  return {
+    ...actual,
+    get runtimeName() {
+      return runtime.name
+    },
+  }
+})
+
+/** Set env vars for one test, restoring prior values afterward. */
+const testEnv = (
+  globalThis as { process?: { env: Record<string, string | undefined> } }
+).process!.env
+const envCleanup: Array<() => void> = []
+function setEnv(name: string, value: string | undefined) {
+  const prior = testEnv[name]
+  if (value === undefined) delete testEnv[name]
+  else testEnv[name] = value
+  envCleanup.push(() => {
+    if (prior === undefined) delete testEnv[name]
+    else testEnv[name] = prior
+  })
+}
+
+afterEach(() => {
+  while (envCleanup.length) envCleanup.pop()!()
+  runtime.name = 'node'
+})
+
+describe('isEdgeFunctions', () => {
+  it('is true when SUPABASE_FUNCTION_SLUG is set, whatever the runtime reports', () => {
+    setEnv('SUPABASE_FUNCTION_SLUG', 'my-fn')
+    setEnv('SB_EXECUTION_ID', undefined)
+    runtime.name = 'node'
+    expect(isEdgeFunctions()).toBe(true)
+  })
+
+  it('is true when SB_EXECUTION_ID is set and std-env reports edge-light (Supabase edge runtime exposes an EdgeRuntime global)', () => {
+    setEnv('SUPABASE_FUNCTION_SLUG', undefined)
+    setEnv('SB_EXECUTION_ID', '2f1a0c9e-7d5b-4b1e-9c3a-0f6d2b8e4a11')
+    runtime.name = 'edge-light'
+    expect(isEdgeFunctions()).toBe(true)
+  })
+
+  it('is true on a plain Deno runtime with no Supabase markers', () => {
+    setEnv('SUPABASE_FUNCTION_SLUG', undefined)
+    setEnv('SB_EXECUTION_ID', undefined)
+    runtime.name = 'deno'
+    expect(isEdgeFunctions()).toBe(true)
+  })
+
+  it('is false on Node with no Supabase markers', () => {
+    setEnv('SUPABASE_FUNCTION_SLUG', undefined)
+    setEnv('SB_EXECUTION_ID', undefined)
+    runtime.name = 'node'
+    expect(isEdgeFunctions()).toBe(false)
+  })
+
+  it('is false on a real edge-light runtime (Vercel Edge) with no Supabase markers', () => {
+    setEnv('SUPABASE_FUNCTION_SLUG', undefined)
+    setEnv('SB_EXECUTION_ID', undefined)
+    runtime.name = 'edge-light'
+    expect(isEdgeFunctions()).toBe(false)
+  })
+})

--- a/src/oauth-protected-resource/runtime.ts
+++ b/src/oauth-protected-resource/runtime.ts
@@ -8,12 +8,20 @@ import { getEnv, runtimeName } from '@supabase/middleware'
  * `/functions/v1` prefix; off platform those headers describe the app's own
  * origin, which is unrelated to the Supabase project.
  *
- * True when `SUPABASE_FUNCTION_SLUG` is set, or when the host runtime is Deno.
- * A plain Deno server or Deno Deploy therefore reads as Edge Functions.
+ * True when `SUPABASE_FUNCTION_SLUG` or `SB_EXECUTION_ID` is set, or when the
+ * host runtime is Deno. A plain Deno server or Deno Deploy therefore reads as
+ * Edge Functions.
+ *
+ * The runtime name alone cannot identify Supabase's edge runtime: it exposes an
+ * `EdgeRuntime` global, which std-env classifies as `edge-light` before it
+ * checks for Deno. `SB_EXECUTION_ID` is set by the edge runtime itself for
+ * every invocation, hosted and local, so it is the marker that holds when the
+ * gateway does not inject a slug.
  *
  * @internal
  */
 export function isEdgeFunctions(): boolean {
   if (getEnv('SUPABASE_FUNCTION_SLUG')) return true
+  if (getEnv('SB_EXECUTION_ID')) return true
   return runtimeName === 'deno'
 }

--- a/src/oauth-protected-resource/url.ts
+++ b/src/oauth-protected-resource/url.ts
@@ -1,4 +1,4 @@
-import { getEnv } from '@supabase/middleware'
+import { getEnv, runtimeName } from '@supabase/middleware'
 
 import {
   Errors,
@@ -108,7 +108,7 @@ function edgeResourcePath(req: Request): string {
     '',
   )
   if (received === '' || received === '/') {
-    throw Errors[MissingResourceServerError]()
+    throw Errors[MissingResourceServerError](runtimeName)
   }
   return `${EDGE_FUNCTIONS_PATH_PREFIX}${received}`
 }
@@ -126,7 +126,7 @@ function edgeResourcePath(req: Request): string {
  * @internal
  */
 export function defaultResourceServer(req: Request): string {
-  if (!isEdgeFunctions()) throw Errors[MissingResourceServerError]()
+  if (!isEdgeFunctions()) throw Errors[MissingResourceServerError](runtimeName)
   return `${edgeOrigin(req)}${edgeResourcePath(req)}`
 }
 

--- a/src/oauth-protected-resource/with-oauth-protected-resource.test.ts
+++ b/src/oauth-protected-resource/with-oauth-protected-resource.test.ts
@@ -745,6 +745,20 @@ describe('withOAuthProtectedResource - off-platform defaults fail loudly', () =>
     })
   })
 
+  it('the error reports the detected runtime and the Edge Functions markers', async () => {
+    offEdgeFunctions()
+    clearEnv()
+    const call = withOAuthProtectedResource(passthrough)(
+      req('GET', '/api/mcp/oauth-protected-resource'),
+    )
+    // `runtimeName` is std-env's `runtime`, which is `node` under vitest.
+    await expect(call).rejects.toMatchObject({
+      code: MissingResourceServerError,
+      details: { runtime: 'node' },
+      hint: expect.stringMatching(/SUPABASE_FUNCTION_SLUG.*SB_EXECUTION_ID/),
+    })
+  })
+
   it('a fully configured stack never reaches the env at all', async () => {
     offEdgeFunctions()
     clearEnv()


### PR DESCRIPTION
Inside Supabase's edge runtime, `isEdgeFunctions()` returned false unless the gateway injected `SUPABASE_FUNCTION_SLUG`: std-env classifies the runtime as `edge-light` (it exposes an `EdgeRuntime` global) rather than `deno`, so on a CLI older than [cli#6345](https://github.com/supabase/cli/pull/6345) every zero-config `withOAuthProtectedResource()` request failed with `MISSING_RESOURCE_SERVER` as a raw 500. `isEdgeFunctions()` now also returns true when `SB_EXECUTION_ID` is set, which the edge runtime injects into every worker, hosted and local, so detection no longer depends on the CLI version. Adds unit tests for the predicate (slug set, `SB_EXECUTION_ID` under `edge-light`, plain Deno, Node, and a real `edge-light` host staying false) and documents the marker in the environment variables and error handling docs.

Fixes [SDK-1768](https://linear.app/supabase/issue/SDK-1768).