### PR TITLE
fix: default Database generic to any, matching createClient()

### DIFF
--- a/docs/adapters/nestjs.md
+++ b/docs/adapters/nestjs.md
@@ -40,7 +40,7 @@ export class GamesController {
 
 ### Typing your database
 
-The guard does not thread a `Database` generic, so `@SupabaseCtx()` resolves to `SupabaseContext<unknown>` by default. To get typed table access, annotate the parameter at the handler:
+The guard does not thread a `Database` generic, so `@SupabaseCtx()` resolves to `SupabaseContext<any>` by default. To get typed table access, annotate the parameter at the handler:
 
 ```ts
 import type { SupabaseContext } from '@supabase/server'

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,7 +9,7 @@ Complete reference for every export, organized by entry point.
 ### withSupabase
 
 ```ts
-function withSupabase<Database = unknown>(
+function withSupabase<Database = UntypedDatabase>(
   config: WithSupabaseConfig,
   handler: (req: Request, ctx: SupabaseContext<Database>) => Promise<Response>,
 ): (req: Request) => Promise<Response>
@@ -25,7 +25,7 @@ Wraps a fetch handler with auth, CORS, and client creation. Returns a `(req: Req
 - Reading the raw `req.body` stream bypasses the buffer, so a handler that forwards the request with `fetch()` after another layer has read the body rebuilds it from `await req.arrayBuffer()`.
 
 ```ts
-function withSupabase<Database = unknown>(
+function withSupabase<Database = UntypedDatabase>(
   config: WithSupabaseConfig,
 ): Entry<SupabaseContext<Database>>
 ```
@@ -56,7 +56,7 @@ Entries before `withSupabase` see every request, including unauthenticated ones,
 ### createSupabaseContext
 
 ```ts
-function createSupabaseContext<Database = unknown>(
+function createSupabaseContext<Database = UntypedDatabase>(
   request: Request,
   options?: WithSupabaseConfig,
 ): Promise<
@@ -122,7 +122,7 @@ Resolves Supabase environment configuration from runtime variables. `SUPABASE_UR
 ### createContextClient
 
 ```ts
-function createContextClient<Database = unknown>(
+function createContextClient<Database = UntypedDatabase>(
   options?: CreateContextClientOptions,
 ): SupabaseClient<Database>
 ```
@@ -138,7 +138,7 @@ Configured with:
 ### createAdminClient
 
 ```ts
-function createAdminClient<Database = unknown>(
+function createAdminClient<Database = UntypedDatabase>(
   options?: CreateAdminClientOptions,
 ): SupabaseClient<Database>
 ```
@@ -549,7 +549,7 @@ withSupabase({ auth: 'none' }, handler) // no credentials required
 ### SupabaseContext\<Database\>
 
 ```ts
-interface SupabaseContext<Database = unknown> {
+interface SupabaseContext<Database = UntypedDatabase> {
   supabase: SupabaseClient<Database>
   supabaseAdmin: SupabaseClient<Database>
   userClaims: UserClaims | null

--- a/docs/typescript-generics.md
+++ b/docs/typescript-generics.md
@@ -4,6 +4,8 @@
 
 All client-creating functions accept a `Database` generic parameter. When you pass your generated database types, every `.from('table').select()` call is fully typed — column names, return types, insert shapes, and RPC signatures.
 
+Without one, `Database` defaults to `any` — the same default `createClient()` uses in `@supabase/supabase-js` — so `.from()`, `.select()`, `.insert()`, and `.update()` all type-check without a generated schema.
+
 ## Generating types
 
 Use the Supabase CLI to generate TypeScript types from your database schema:

--- a/src/adapters/elysia/plugin.ts
+++ b/src/adapters/elysia/plugin.ts
@@ -2,7 +2,11 @@ import { Elysia, type ExtractErrorFromHandle } from 'elysia'
 
 import { createSupabaseContext } from '../../create-supabase-context.js'
 import type { AuthError } from '../../errors.js'
-import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
+import type {
+  SupabaseContext,
+  UntypedDatabase,
+  WithSupabaseConfig,
+} from '../../types.js'
 
 /**
  * Wraps an {@link AuthError} as an Elysia-compatible error.
@@ -70,7 +74,7 @@ export class SupabaseError extends Error {
 // `{}` literals — switching to `object` or `Record<string, never>` would not satisfy
 // the corresponding generic constraints.
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-export function withSupabase<Database = unknown>(
+export function withSupabase<Database = UntypedDatabase>(
   config?: Omit<WithSupabaseConfig, 'cors'>,
 ): Elysia<
   '',

--- a/src/adapters/hono/middleware.ts
+++ b/src/adapters/hono/middleware.ts
@@ -3,7 +3,11 @@ import { createMiddleware } from 'hono/factory'
 import { HTTPException } from 'hono/http-exception'
 
 import { createSupabaseContext } from '../../create-supabase-context.js'
-import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
+import type {
+  SupabaseContext,
+  UntypedDatabase,
+  WithSupabaseConfig,
+} from '../../types.js'
 
 /**
  * Hono middleware that creates a {@link SupabaseContext} and stores it in `c.var.supabaseContext`.
@@ -40,7 +44,7 @@ import type { SupabaseContext, WithSupabaseConfig } from '../../types.js'
  *
  * @category Adapters
  */
-export function withSupabase<Database = unknown>(
+export function withSupabase<Database = UntypedDatabase>(
   config?: Omit<WithSupabaseConfig, 'cors'>,
 ): MiddlewareHandler<{
   Variables: { supabaseContext: SupabaseContext<Database> }

--- a/src/core/create-admin-client.ts
+++ b/src/core/create-admin-client.ts
@@ -5,7 +5,7 @@ import {
   MissingDefaultSecretKeyError,
   MissingSecretKeyError,
 } from '../errors.js'
-import type { CreateAdminClientOptions } from '../types.js'
+import type { CreateAdminClientOptions, UntypedDatabase } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
 /**
@@ -39,7 +39,7 @@ import { resolveEnv } from './resolve-env.js'
  *
  * @category Primitives
  */
-export function createAdminClient<Database = unknown>(
+export function createAdminClient<Database = UntypedDatabase>(
   options?: CreateAdminClientOptions,
 ): SupabaseClient<Database> {
   const { data: resolved, error } = resolveEnv(options?.env)

--- a/src/core/create-context-client.ts
+++ b/src/core/create-context-client.ts
@@ -5,7 +5,7 @@ import {
   MissingDefaultPublishableKeyError,
   MissingPublishableKeyError,
 } from '../errors.js'
-import type { CreateContextClientOptions } from '../types.js'
+import type { CreateContextClientOptions, UntypedDatabase } from '../types.js'
 import { resolveEnv } from './resolve-env.js'
 
 /**
@@ -37,7 +37,7 @@ import { resolveEnv } from './resolve-env.js'
  *
  * @category Primitives
  */
-export function createContextClient<Database = unknown>(
+export function createContextClient<Database = UntypedDatabase>(
   options?: CreateContextClientOptions,
 ): SupabaseClient<Database> {
   const { data: resolved, error } = resolveEnv(options?.env)

--- a/src/create-supabase-context.ts
+++ b/src/create-supabase-context.ts
@@ -7,7 +7,11 @@ import {
   EnvError,
   Errors,
 } from './errors.js'
-import type { SupabaseContext, WithSupabaseConfig } from './types.js'
+import type {
+  SupabaseContext,
+  UntypedDatabase,
+  WithSupabaseConfig,
+} from './types.js'
 
 /**
  * Creates a {@link SupabaseContext} directly from a request.
@@ -32,7 +36,7 @@ import type { SupabaseContext, WithSupabaseConfig } from './types.js'
  * const { data } = await ctx.supabase.rpc('get_my_items')
  * ```
  */
-export async function createSupabaseContext<Database = unknown>(
+export async function createSupabaseContext<Database = UntypedDatabase>(
   request: Request,
   options?: WithSupabaseConfig,
 ): Promise<

--- a/src/middleware/admin-client/index.ts
+++ b/src/middleware/admin-client/index.ts
@@ -6,7 +6,7 @@ import { createAdminClient } from '../../core/create-admin-client.js'
 import { lazyClient } from '../../core/lazy-client.js'
 import { readUpstreamAuth } from '../../core/read-upstream-auth.js'
 import { CreateSupabaseClientError, EnvError, Errors } from '../../errors.js'
-import type { CreateAdminClientOptions } from '../../types.js'
+import type { CreateAdminClientOptions, UntypedDatabase } from '../../types.js'
 
 /**
  * **Alpha.** Configuration for {@link withSupabaseAdminClient} — the same
@@ -90,7 +90,7 @@ const base = defineMiddleware<
  * @alpha
  * @category Middleware
  */
-export function withSupabaseAdminClient<Database = unknown>(
+export function withSupabaseAdminClient<Database = UntypedDatabase>(
   config?: WithSupabaseAdminClientConfig,
 ): Entry<{ supabaseAdmin: SupabaseClient<Database> }> {
   return base(config) as unknown as Entry<{

--- a/src/middleware/client/index.ts
+++ b/src/middleware/client/index.ts
@@ -7,7 +7,10 @@ import { extractCredentials } from '../../core/extract-credentials.js'
 import { readUpstreamAuth } from '../../core/read-upstream-auth.js'
 import { CreateSupabaseClientError, EnvError, Errors } from '../../errors.js'
 import { markConstructionFailure } from '../../core/parts/construction-failure.js'
-import type { CreateContextClientOptions } from '../../types.js'
+import type {
+  CreateContextClientOptions,
+  UntypedDatabase,
+} from '../../types.js'
 
 /**
  * **Alpha.** Configuration for {@link withSupabaseClient} — the same
@@ -97,7 +100,7 @@ const base = defineMiddleware<
  * @alpha
  * @category Middleware
  */
-export function withSupabaseClient<Database = unknown>(
+export function withSupabaseClient<Database = UntypedDatabase>(
   config?: WithSupabaseClientConfig,
 ): Entry<{ supabase: SupabaseClient<Database> }> {
   return base(config) as unknown as Entry<{

--- a/src/types.ts
+++ b/src/types.ts
@@ -453,13 +453,23 @@ export interface CreateAdminClientOptions {
 }
 
 /**
+ * Default for the `Database` generic on every client-creating function and on
+ * {@link SupabaseContext} itself — mirrors `createClient()` from
+ * `@supabase/supabase-js`, so an untyped `withSupabase(...)` call type-checks
+ * the same way an untyped `createClient()` does.
+ * @category Types
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type UntypedDatabase = any
+
+/**
  * The Supabase context created for each authenticated request.
  *
  * Contains pre-configured Supabase clients and the caller's identity.
  * Identical regardless of which layer or adapter produced it.
  * @category Types
  */
-export interface SupabaseContext<Database = unknown> {
+export interface SupabaseContext<Database = UntypedDatabase> {
   /** Supabase client scoped to the caller's identity. RLS policies apply. */
   supabase: SupabaseClient<Database>
 

--- a/src/with-supabase.ts
+++ b/src/with-supabase.ts
@@ -16,6 +16,7 @@ import { withSupabaseClient } from './middleware/client/index.js'
 import type {
   AuthModeWithKey,
   SupabaseContext,
+  UntypedDatabase,
   WithSupabaseConfig,
 } from './types.js'
 
@@ -148,7 +149,7 @@ function rejectMiddlewareOption(config: WithSupabaseConfig): void {
  * ```
  */
 export function withSupabase<
-  Database = unknown,
+  Database = UntypedDatabase,
   Base extends BaseContext = BaseContext,
 >(
   config: WithSupabaseConfig,
@@ -193,7 +194,7 @@ export function withSupabase<
  * }
  * ```
  */
-export function withSupabase<Database = unknown>(
+export function withSupabase<Database = UntypedDatabase>(
   config: WithSupabaseConfig,
 ): Entry<SupabaseContext<Database>>
 


### PR DESCRIPTION
Defaults the `Database` generic to `any` instead of `unknown` across every client-creating function (`withSupabase`, `withSupabaseClient`, `withSupabaseAdminClient`, `createSupabaseContext`, `createContextClient`, `createAdminClient`, and both the Hono and Elysia adapters), plus `SupabaseContext` itself. Previously an unannotated write failed type-checking, for example `ctx.supabase.from('t').insert({...})` resolved to `not assignable to parameter of type 'never'`, forcing every untyped consumer into a `withSupabase<any>(...)` workaround just to compile.

This matches [`createClient()` in `@supabase/supabase-js`](https://github.com/supabase/supabase-js/blob/29b978d5da37cbb1927b1e8a8013c6f47e7223c8/packages/core/supabase-js/src/index.ts#L48-L49), which has always defaulted its own `Database` generic to `any`. Nobody loses type safety who wants it: pass generated database types the same way as before, `withSupabase<Database>(...)`, and every table and RPC call stays fully typed. Only the unannotated path changes, from a compile error to a permissive default.

The `any` default is centralized in one named alias, `UntypedDatabase`, in `types.ts`, rather than repeated as a bare `any` at each call site. Docs (`typescript-generics.md`, `api-reference.md`, `adapters/nestjs.md`) are updated to match.